### PR TITLE
CE-422 Force files to be mono after converting

### DIFF
--- a/functions/services/audio.js
+++ b/functions/services/audio.js
@@ -95,6 +95,9 @@ function convert (sourceFile, destinationPath) {
     const command = ffmpeg(sourceFile)
       .noVideo()
       .output(destinationPath)
+      .outputOptions([
+        '-ac 1'
+      ])
       .on('start', function (commandLine) {
         // console.log('Spawned Ffmpeg with command: ' + commandLine)
       }).on('progress', function (progress) {


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-433](https://jira.rfcx.org/browse/CE-422)
- [x] API docs n/a
- [x] Release notes n/a
- [x] Deployment notes n/a
- [x] Unit tests n/a

## 📝 Summary

- Force audio channel to be 'mono' when converting any files

## 🛑 Problems

- ~~Other metadata from AudioMoth (e.g. bit per rate, comment) are disappeared after converting.~~ [Rechecked - doesn't relevant anymore]