### PR TITLE
CE-469 Use one endpoint for source file and segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ node_modules/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
+.env*
 .env-*
 serviceAccountKeyStorage.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 ### Features
 * Save ingested error files to error directory ([PI-670](https://jira.rfcx.org/browse/PI-670))
 
+### Performance Improvements
+* Refactor ingestion code to be shorter and simpler ([CE-469](https://jira.rfcx.org/browse/CE-469))
+
+### Bug Fixes
+* Use one endpoint for stream_source_file and stream_segment creation ([CE-469](https://jira.rfcx.org/browse/CE-469))
+
 <a name="1.0.3"></a>
 ## 1.0.3 (2021-03-15)
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,11 +4,17 @@ const platform = process.env.PLATFORM
 console.log(`Environment set to ${platform}`)
 
 const api = require('./api')
+const setup = require('./services/setup')
 
-const port = process.env.PORT || 3030
-api.listen(port, () => {
-  console.log(`App is listening on port ${port}`)
-})
+async function main () {
+  await setup()
+  const port = process.env.PORT || 3030
+  api.listen(port, () => {
+    console.log(`App is listening on port ${port}`)
+  })
 
-const ingestConsumer = require(`./services/consumer/${platform}`)
-ingestConsumer.start()
+  const ingestConsumer = require(`./services/consumer/${platform}`)
+  ingestConsumer.start()
+}
+
+main()

--- a/functions/services/arbimon.js
+++ b/functions/services/arbimon.js
@@ -1,15 +1,40 @@
 const axios = require('axios')
 const { matchAxiosErrorToRfcx } = require('../utils/errors')
+const auth0Service = require('./auth0')
 
 const arbimonHost = process.env.ARBIMON_HOST
 
-function createRecording (opts, idToken) {
+async function createRecordingsFromFiles (outputFiles, upload) {
+  let totalDurationMs = 0
+  for (const file of outputFiles) {
+    const duration = file.meta.duration
+    const recording = {
+      site_external_id: upload.streamId,
+      uri: file.remotePath,
+      datetime: file.start,
+      sample_rate: upload.sampleRate || file.meta.sampleRate,
+      precision: 0,
+      duration,
+      samples: file.meta.sampleCount,
+      file_size: file.meta.size,
+      bit_rate: upload.targetBitrate || file.meta.bitRate,
+      sample_encoding: file.meta.codec
+    }
+    totalDurationMs += duration
+    console.log(`Creating recording ${recording.uri} in the Arbimon`, recording)
+    await createRecording(recording)
+  }
+}
+
+async function createRecording (opts) {
   const url = `${arbimonHost}api/ingest/recordings/create`
   const data = {};
   ['project_id', 'site_external_id', 'uri', 'datetime', 'sample_rate', 'precision',
     'duration', 'samples', 'file_size', 'bit_rate', 'sample_encoding'].forEach(attr => data[attr] = opts[attr])
+
+  const token = await auth0Service.getToken()
   const headers = {
-    Authorization: idToken,
+    Authorization: `Bearer ${token.access_token}`,
     'Content-Type': 'application/json'
   }
 
@@ -21,5 +46,6 @@ function createRecording (opts, idToken) {
 }
 
 module.exports = {
+  createRecordingsFromFiles,
   createRecording
 }

--- a/functions/services/audio.js
+++ b/functions/services/audio.js
@@ -1,4 +1,5 @@
 const ffmpeg = require('fluent-ffmpeg')
+const sha1File = require('sha1-file')
 const path = require('path')
 
 /**
@@ -27,7 +28,8 @@ function identify (sourceFile) {
           const codec = stream.codec_name
           const tags = result.format && result.format.tags ? result.format.tags : {}
           const size = result.format && result.format.size ? result.format.size : 0
-          resolve({ format, duration, sampleCount, channelLayout, channelCount, bitRate, sampleRate, codec, tags, size })
+          const checksum = sha1File(sourceFile)
+          resolve({ format, duration, sampleCount, channelLayout, channelCount, bitRate, sampleRate, codec, tags, size, checksum })
         }
       })
   })

--- a/functions/services/setup.js
+++ b/functions/services/setup.js
@@ -1,0 +1,5 @@
+const dirUtil = require('../utils/dir')
+
+module.exports = async function () {
+  await dirUtil.ensureDirExists(process.env.CACHE_DIRECTORY)
+}


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-469](https://jira.rfcx.org/browse/CE-469)
- [x] Release notes updated
- [x] Deployment notes n/a
- [x] Unit tests n/a

## 📝 Summary

- Ingestion code is refactored to be shorter and simpler
- Segment files are uploaded in parallel instead of sequence
- Now a single endpoint is used for stream_source_file and stream_segment creation which works in transaction

## 📸 Examples

## 🛑 Problems

## 💡 More ideas
