### PR TITLE
CE-1264 Parse sample rate from guardian audio filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+<a name="1.0.8"></a>
+## 1.0.8 (2021-08-XX)
+
+### Features
+* Parse sample rate from guardian audio filename ([CE-1264](https://jira.rfcx.org/browse/CE-1264))
+
 <a name="1.0.7"></a>
 ## 1.0.7 (2021-08-05)
 
 ### Features
 * Add user permissions into get projects endpoint ([CE-1175](https://jira.rfcx.org/browse/CE-1175))
-* Parse sample rate from guardian audio filename ([CE-1264](https://jira.rfcx.org/browse/CE-1264))
 
 <a name="1.0.6"></a>
 ## 1.0.6 (2021-08-03)

--- a/routes/uploads.int.test.js
+++ b/routes/uploads.int.test.js
@@ -175,30 +175,6 @@ describe('POST /uploads', () => {
     expect(upload.targetBitrate).toBe(requestBody.targetBitrate)
     expect(upload.checksum).toBe(requestBody.checksum)
   })
-  test('creates upload document for guardian audio file with incorrect filename', async () => {
-    const requestBody = {
-      filename: 'okn3p9_2014-12-31T21-04-10.261-0300_24kHz_90.923secs.opus',
-      timestamp: '2015-01-01T00:04:10.261Z',
-      stream: 'p0gccfokn3p9',
-      checksum: 'bcd44fdcc42e0dad141f35ae1aa029fd6b3f9eca',
-      targetBitrate: 1
-    }
-    const response = await request(app).post('/uploads').send(requestBody)
-    const upload = await UploadModel.findOne({ checksum: requestBody.checksum })
-    expect(response.statusCode).toBe(200)
-    expect(response.body.uploadId).toBeDefined()
-    expect(response.body.url).toBe('http://some.url')
-    expect(response.body.path).toBeDefined()
-    expect(response.body.bucket).toBe('streams-uploads')
-    expect(upload.originalFilename).toBe(requestBody.filename)
-    expect(upload.streamId).toBe(requestBody.stream)
-    expect(upload.userId).toBe(seedValues.primaryUserGuid)
-    expect(upload.status).toBe(status.WAITING)
-    expect(upload.timestamp.toISOString()).toEqual(requestBody.timestamp)
-    expect(upload.sampleRate).toBeUndefined()
-    expect(upload.targetBitrate).toBe(requestBody.targetBitrate)
-    expect(upload.checksum).toBe(requestBody.checksum)
-  })
   test('does not call segmentService.getExistingSourceFiles if checksum is not provided', async () => {
     const requestBody = {
       filename: '0a1824085e3f-2021-06-08T19-26-40.flac',

--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -7,7 +7,7 @@ const storage = require(`../services/storage/${platform}`)
 const segmentService = require('../services/rfcx/segments')
 const streamService = require('../services/rfcx/streams')
 const auth0Service = require('../services/auth0')
-const { parseGuardianAudioFilename } = require('../services/rfcx/guardian')
+const { getSampleRateFromFilename } = require('../services/rfcx/guardian')
 
 /**
  * @swagger
@@ -71,8 +71,8 @@ router.route('/').post((req, res) => {
           throw new ValidationError(message)
         }
       }
-      const gData = parseGuardianAudioFilename(params.filename)
-      sampleRate = sampleRate || gData.sampleRate || undefined
+      const gSampleRate = getSampleRateFromFilename(params.filename)
+      sampleRate = sampleRate || gSampleRate
       const upload = await db.generateUpload({
         streamId: stream,
         userId,

--- a/services/rfcx/guardian.js
+++ b/services/rfcx/guardian.js
@@ -1,33 +1,19 @@
-const moment = require('moment')
-
 /**
  * Parses audio and stream data based on information stored in filename
  * @param {*} name example: p0gccfokn3p9_2014-12-31T21-04-10.261-0300_24kHz_90.923secs.opus
- * @returns {Object} data parsed guardian audio data
- * @returns {string} data.streamId guardian/stream id
- * @returns {Moment} data.timestamp moment.js object with datetime
- * @returns {number} data.sampleRate audio sample rate
- * @returns {number} data.duration audio duration
+ * @returns {number} audio sample rate
  */
-function parseGuardianAudioFilename (name) {
-  let streamId, timestamp, sampleRate, duration
+function getSampleRateFromFilename (name) {
+  let sampleRate
   try {
-    const matches = name.match(/^(?<id>(\d|\w{12}))_(?<ts>\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}.\d{3}-\d{4})_(?<sr>\d+)kHz_(?<du>\d+.\d+)secs/)
-    const { id, ts, sr, du } = matches.groups
-    streamId = id
-    timestamp = moment(ts, 'YYYY-MM-DDTHH-mm-ss.SSSZZ')
-    sampleRate = sr * 1000
-    duration = parseFloat(du)
-    if (!streamId || !timestamp || !sampleRate || !duration) { // if some of the fields were parsed incorrectly, reset other fields
-      streamId = undefined
-      timestamp = undefined
-      sampleRate = undefined
-      duration = undefined
+    const matches = name.match(/_(?<sr>\d+\.*\d*)kHz_/i)
+    if (matches.groups.sr) {
+      sampleRate = matches.groups.sr * 1000
     }
   } catch (e) { }
-  return { streamId, timestamp, sampleRate, duration }
+  return sampleRate
 }
 
 module.exports = {
-  parseGuardianAudioFilename
+  getSampleRateFromFilename
 }

--- a/services/rfcx/guardian.test.js
+++ b/services/rfcx/guardian.test.js
@@ -1,39 +1,31 @@
-const { parseGuardianAudioFilename } = require('./guardian')
+const { getSampleRateFromFilename } = require('./guardian')
 
-describe('parseGuardianAudioFilename', () => {
-  test('should return correct data for valid guardian filename', () => {
-    const data = parseGuardianAudioFilename('p0gccfokn3p9_2014-12-31T21-04-10.261-0300_24kHz_90.923secs.opus')
-    expect(data.streamId).toEqual('p0gccfokn3p9')
-    expect(data.timestamp.toISOString()).toEqual('2015-01-01T00:04:10.261Z')
-    expect(data.sampleRate).toEqual(24000)
-    expect(data.duration).toEqual(90.923)
+describe('getSampleRateFromFilename', () => {
+  test('should return 24000', () => {
+    expect(getSampleRateFromFilename('p0gccfokn3p9_2014-12-31T21-04-10.261-0300_24kHz_90.923secs.opus')).toEqual(24000)
   })
-  test('should return correct data for another valid guardian filename', () => {
-    const data = parseGuardianAudioFilename('47c7pyc0uobq_2021-05-13T00-54-12.981-0530_48kHz_0.923secs.opus')
-    expect(data.streamId).toEqual('47c7pyc0uobq')
-    expect(data.timestamp.toISOString()).toEqual('2021-05-13T06:24:12.981Z')
-    expect(data.sampleRate).toEqual(48000)
-    expect(data.duration).toEqual(0.923)
+  test('should return 48000', () => {
+    expect(getSampleRateFromFilename('47c7pyc0uobq_2021-05-13T00-54-12.981-0530_48kHz_0.923secs.opus')).toEqual(48000)
   })
-  test('should return undefined if filename is cutted at start', () => {
-    const data = parseGuardianAudioFilename('0gccfokn3p9_2014-12-31T21-04-10.261-0300_24kHz_90.923secs.opus')
-    expect(data.streamId).toBeUndefined()
-    expect(data.timestamp).toBeUndefined()
-    expect(data.sampleRate).toBeUndefined()
-    expect(data.duration).toBeUndefined()
+  test('should return 44100', () => {
+    expect(getSampleRateFromFilename('47c7pyc0uobq_2021-05-13T00-54-12.981-0530_44.1kHz_0.923secs.opus')).toEqual(44100)
+  })
+  test('should return 8000', () => {
+    expect(getSampleRateFromFilename('47c7pyc0uobq_2021-05-13T00-54-12.981-0530_8kHz_0.923secs.opus')).toEqual(8000)
+  })
+  test('should return 4000', () => {
+    expect(getSampleRateFromFilename('47c7pyc0uobq_2021-05-13T00-54-12.981-0530_4.kHz_0.923secs.opus')).toEqual(4000)
+  })
+  test('should return undefined for _kHz_', () => {
+    expect(getSampleRateFromFilename('47c7pyc0uobq_2021-05-13T00-54-12.981-0530_kHz_0.923secs.opus')).toBeUndefined()
+  })
+  test('should return correct result if khz is lowercased', () => {
+    expect(getSampleRateFromFilename('47c7pyc0uobq_2021-05-13T00-54-12.981-0530_12khz_0.923secs.opus')).toBe(12000)
   })
   test('should return undefined for an AudioMoth filename', () => {
-    const data = parseGuardianAudioFilename('20210310_140000.flac')
-    expect(data.streamId).toBeUndefined()
-    expect(data.timestamp).toBeUndefined()
-    expect(data.sampleRate).toBeUndefined()
-    expect(data.duration).toBeUndefined()
+    expect(getSampleRateFromFilename('20210310_140000.flac')).toBeUndefined()
   })
   test('should return undefined for a random filename', () => {
-    const data = parseGuardianAudioFilename('some_name.wav')
-    expect(data.streamId).toBeUndefined()
-    expect(data.timestamp).toBeUndefined()
-    expect(data.sampleRate).toBeUndefined()
-    expect(data.duration).toBeUndefined()
+    expect(getSampleRateFromFilename('some_name.wav')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-1264](https://jira.rfcx.org/browse/CE-1264)
- [x] API docs n/a
- [x] Release notes updated
- [x] Deployment notes n/a
- [x] Unit tests added

## 📝 Summary

- Added a service which parses filename and if it matched guardian audio filename format, returns data including sample rate which is used for upload creation
- If sample rate is provided in request payload, it will override sample rate which is parsed from filename

## 📸 Examples

## 🛑 Problems

## 💡 More ideas
