### PR TITLE
Receive segment ids from core

### DIFF
--- a/services/rfcx/segments.js
+++ b/services/rfcx/segments.js
@@ -71,7 +71,10 @@ async function createStreamFileData (stream, payload) {
       if (!response || response.status !== 201) {
         throw new Error('Stream source file was not created')
       }
-      return response.headers.location.replace('/stream-source-files/', '')
+      return {
+        streamSourceFileId: response.headers.location.replace('/stream-source-files/', ''),
+        streamSegments: response.body.stream_segments
+      }
     })
     .catch((err) => {
       if (err.response && err.response.data && err.response.data.message) {


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #XXX
- [x] API docs n/a
- [x] Release notes n/a
- [x] Deployment notes n/a
- [x] Unit tests added n/a

## 📝 Summary

- Receive segment ids from Core API side and use them to build upload file path

## 📸 Examples

## 🛑 Problems

## 💡 More ideas
