### PR TITLE
Not include very small segment to Core API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="1.1.1"></a>
+## 1.1.1 (2024-06-xx)
+
+### Bug Fixes
+* Not include very small segments to Core API
+
 <a name="1.1.0"></a>
 ## 1.1.0 (2024-02-xx)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ingest-service",
   "description": "Ingest Service",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "dev": "nodemon main-all.js",
     "start": "node main-all.js",

--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -177,7 +177,7 @@ function combineSourceFileData (fileData, wavMeta, upload) {
  * @param {*} upload
  */
 function combineSegmentsData (outputFiles, upload) {
-  return outputFiles.map((file) => {
+  const combinedData = outputFiles.map((file) => {
     return {
       id: file.guid,
       stream: upload.streamId,
@@ -188,6 +188,14 @@ function combineSegmentsData (outputFiles, upload) {
       fileSize: file.meta.size
     }
   })
+  /*
+  * There is a very rare case that the segment is very small, 0.0000x second.
+  * With this small segment, the sample count will be null so we have to exclude it
+  */
+  if (!combinedData[combinedData.length - 1].sampleCount) {
+    combinedData.pop()
+  }
+  return combinedData
 }
 
 /**


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #81 
- [x] Release notes updated 

_(use n/a when API docs (Release notes, etc) do not need to be updated)_

## 📝 Summary

- Check the last file sample count, if it is null then pop it out and send only valid ones
