### PR TITLE
Support S3-compatible endpoint via AWS_S3_ENDPOINT

### DIFF
--- a/services/storage/amazon.js
+++ b/services/storage/amazon.js
@@ -3,9 +3,17 @@ const fs = require('fs')
 
 const uploadBucket = process.env.UPLOAD_BUCKET
 
-const s3Client = new AWS.S3({
+// rfcx-local fork: support an S3-compatible endpoint (MinIO, B2, R2,
+// in-cluster s3-cache, etc.) when AWS_S3_ENDPOINT is set. With it unset,
+// behavior is bit-identical to upstream: vanilla AWS S3.
+const _s3Config = {
   signatureVersion: 'v4'
-})
+}
+if (process.env.AWS_S3_ENDPOINT) {
+  _s3Config.endpoint = process.env.AWS_S3_ENDPOINT
+  _s3Config.s3ForcePathStyle = process.env.AWS_S3_FORCE_PATH_STYLE === 'true'
+}
+const s3Client = new AWS.S3(_s3Config)
 
 function getSignedUrl (filePath, contentType) {
   const params = {


### PR DESCRIPTION
## Summary

When `AWS_S3_ENDPOINT` is unset, behavior is bit-identical to before: S3 client talks to default AWS S3 with creds + region.

When `AWS_S3_ENDPOINT` is set, the client also receives:
- `endpoint` from `AWS_S3_ENDPOINT`
- `s3ForcePathStyle` from `AWS_S3_FORCE_PATH_STYLE === "true"`
- `signatureVersion: v4` (already present)

This is what MinIO, B2, R2, and the in-cluster s3-cache all need.

## Why

Today `ingest-service` ignores `AWS_S3_ENDPOINT` entirely. Every signed URL returned by `POST /uploads` looks like `https://<bucket>.s3.eu-west-1.amazonaws.com/...` regardless of env. That means devices PUT raw audio direct to AWS S3, and `tasks` reads/writes direct to AWS S3 — bypassing rfcx-local's edge / s3-cache. Confirmed empirically by calling `getSignedUrl` from inside the apps-prod pod at 11:27 EDT today.

## Pattern

Mirrors rfcx/rfcx-api commit `526630aa9` (*"Support S3-compatible endpoint (MinIO) via AWS_S3_ENDPOINT"*) for the same plumbing on the core-api side.

## Risk

Zero for production (`AWS_S3_ENDPOINT` unset → no code change effective). Local cluster behavior changes from "signed URLs point at AWS S3 direct" to "signed URLs point at s3.arbimon.org / s3-cache" — which is what we want.

## Test plan

1. Merge to `staging` → staging deploy goes to AWS staging namespace (env unset there, so no-op).
2. PR `staging → master` when ready → master deploy fires both AWS prod (no-op) and rfcx-local (with env set).
3. From inside rfcx-local apps-prod `ingest-service-api` pod: `getSignedUrl` should now return URL on `s3.arbimon.org` host.
