### PR TITLE
Support RabbitMQ as ingest trigger (INGEST_CONSUMER_TYPE=rabbitmq)

### DIFF
--- a/main-tasks.js
+++ b/main-tasks.js
@@ -9,5 +9,9 @@ api.listen(port, () => {
   console.info(`App is listening on port ${port}`)
 })
 
-const ingestConsumer = require('./services/consumer/amazon')
+// Select ingest consumer implementation.
+//   INGEST_CONSUMER_TYPE=amazon   (default; AWS SQS trigger, legacy)
+//   INGEST_CONSUMER_TYPE=rabbitmq (rfcx-local; RabbitMQ trigger)
+const consumerType = process.env.INGEST_CONSUMER_TYPE || 'amazon'
+const ingestConsumer = require(`./services/consumer/${consumerType}`)
 ingestConsumer.start()

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/storage": "^3.3.1",
     "@mongoosejs/double": "^0.2.0",
     "@rfcx/http-utils": "^1.0.12",
-    "@rfcx/message-queue": "^1.1.0",
+    "@rfcx/message-queue": "github:rfcx/message-queue#1.1.0",
     "@rfcx/prometheus-metrics": "^1.0.3",
     "aws-sdk": "^2.574.0",
     "axios": "^1.6.5",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@google-cloud/storage": "^3.3.1",
     "@mongoosejs/double": "^0.2.0",
     "@rfcx/http-utils": "^1.0.12",
+    "@rfcx/message-queue": "^1.1.0",
     "@rfcx/prometheus-metrics": "^1.0.3",
     "aws-sdk": "^2.574.0",
     "axios": "^1.6.5",

--- a/services/consumer/rabbitmq.js
+++ b/services/consumer/rabbitmq.js
@@ -1,0 +1,70 @@
+const { MessageQueue } = require('@rfcx/message-queue')
+const { ingest } = require('../rfcx/ingest')
+const { parseUploadFromFileName } = require('./misc')
+const TimeTracker = require('../../utils/time-tracker')
+const db = require('../db/mongo')
+
+const flacLimitSize = 150_000_000
+const wavLimitSize = 200_000_000
+
+const queueName = process.env.RABBITMQ_INGEST_TRIGGER_QUEUE || 'ingest-service-upload-production'
+
+const mq = new MessageQueue('rabbitmq')
+
+// Same S3-event payload shape that SQS receives from AWS S3 event notifications;
+// this lets the s3-cache publisher and AWS S3 both feed compatible bodies.
+//   { Records: [ { eventName: "ObjectCreated:Put",
+//                  s3: { bucket: { name, arn }, object: { key, size } } } ] }
+function parseIngestRecords (body) {
+  try {
+    const filesS3Paths = []
+    body.Records.forEach((record) => {
+      if (record.eventName && record.eventName.includes('ObjectCreated:')) {
+        filesS3Paths.push({
+          bucket: {
+            name: record.s3.bucket.name,
+            arn: record.s3.bucket.arn
+          },
+          key: record.s3.object.key,
+          size: record.s3.object.size
+        })
+      }
+    })
+    return filesS3Paths
+  } catch (e) {
+    return []
+  }
+}
+
+async function handleMessage (body) {
+  let tracker = new TimeTracker('IngestConsumer')
+  const files = parseIngestRecords(body)
+  for (const file of files) {
+    const { fileLocalPath, streamId, uploadId } = parseUploadFromFileName(file.key)
+    try {
+      const fileExtension = file.key.split('.').pop().toLowerCase()
+      if (fileExtension === 'flac' && file.size > flacLimitSize) {
+        db.updateUploadStatus(uploadId, db.status.FAILED, `This flac file size is exceeding our limit (${flacLimitSize / 1_000_000}MB)`)
+      } else if (fileExtension === 'wav' && file.size > wavLimitSize) {
+        db.updateUploadStatus(uploadId, db.status.FAILED, `This wav file size is exceeding our limit (${wavLimitSize / 1_000_000}MB)`)
+      } else {
+        await ingest(file.key, fileLocalPath, streamId, uploadId)
+      }
+    } catch (e) {
+      // returning false nacks the message; @rfcx/message-queue rabbitmq
+      // adapter routes nack-no-requeue → DLX, matching SQS-without-redrive
+      // semantics.
+      return false
+    }
+  }
+  tracker.log('processed message')
+  tracker = null
+  return true
+}
+
+function start () {
+  mq.subscribe(queueName, handleMessage)
+  console.info(`Ingest RabbitMQ consumer subscribed to queue "${queueName}"`)
+}
+
+module.exports = { start }

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,6 +955,14 @@
   dependencies:
     moment-timezone "0.5.31"
 
+"@rfcx/message-queue@github:rfcx/message-queue#1.1.0":
+  version "1.1.0"
+  resolved "https://codeload.github.com/rfcx/message-queue/tar.gz/9e94964bc761ae4ca144fbb5da73bb3812bbbe06"
+  dependencies:
+    amqplib "^0.10.4"
+    aws-sdk "^2.988.0"
+    sqs-consumer "^5.6.0"
+
 "@rfcx/prometheus-metrics@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@rfcx/prometheus-metrics/-/prometheus-metrics-1.0.3.tgz#c28728e0f5d9edaef6762b6c03bd52257062b6c8"
@@ -1289,6 +1297,14 @@ alter@~0.2.0:
   dependencies:
     stable "~0.1.3"
 
+amqplib@^0.10.4:
+  version "0.10.9"
+  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.10.9.tgz#5b744c21d624f9307d0399e4d339b7354675831c"
+  integrity sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==
+  dependencies:
+    buffer-more-ints "~1.0.0"
+    url-parse "~1.5.10"
+
 analytics-node@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/analytics-node/-/analytics-node-1.2.2.tgz#322d2546af4ed566ba914468b6ea39636008c5b5"
@@ -1562,6 +1578,22 @@ aws-sdk@^2.1271.0, aws-sdk@^2.574.0:
     uuid "8.0.0"
     xml2js "0.6.2"
 
+aws-sdk@^2.988.0:
+  version "2.1693.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1693.0.tgz#fda38671af3dc5fa8117e9aa09cf6ce37e34010e"
+  integrity sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    util "^0.12.4"
+    uuid "8.0.0"
+    xml2js "0.6.2"
+
 aws-sign2@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.5.0.tgz#c57103f7a17fc037f02d7c2e64b602ea223f7d63"
@@ -1821,6 +1853,11 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer-more-ints@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz#ef4f8e2dddbad429ed3828a9c55d44f05c611422"
+  integrity sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==
 
 buffer@4.9.2:
   version "4.9.2"
@@ -6714,7 +6751,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sqs-consumer@^5.4.0:
+sqs-consumer@^5.4.0, sqs-consumer@^5.6.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/sqs-consumer/-/sqs-consumer-5.8.0.tgz#eb2796bf17e4f703dd93e534bf949f15e7b1fef9"
   integrity sha512-pJReMEtDM9/xzQTffb7dxMD5MKagBfOW65m+ITsbpNk0oZmJ38tTC4LPmj0/7ZcKSOqi2LrpA1b0qGYOwxlHJg==
@@ -6796,7 +6833,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6880,7 +6926,7 @@ stringstream@~0.0.4:
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
   integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6893,6 +6939,13 @@ strip-ansi@^3.0.0:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -7434,7 +7487,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url-parse@^1.5.3:
+url-parse@^1.5.3, url-parse@~1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
@@ -7630,7 +7683,16 @@ wordwrap@0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
   integrity sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Summary

Adds RabbitMQ as an alternative ingest trigger source. When `INGEST_CONSUMER_TYPE=rabbitmq` is set, `ingest-service-tasks` subscribes to a RabbitMQ queue (default `ingest-service-upload-production`) instead of AWS SQS.

When the env is unset or set to `amazon` (default), behavior is bit-identical to before — AWS SQS via `sqs-consumer`.

## Why

`ingest-service-tasks` currently has a hard AWS SQS dependency. For the rfcx-local deployment we're moving the entire data plane off AWS, so we need a local trigger source. RabbitMQ is already deployed in rfcx-local (`platform/rabbitmq/`) with an `ingest-service-upload-production` quorum queue and DLX topology mirroring the prod SQS layout.

## Design

- `services/consumer/rabbitmq.js`: new file (~80 lines) using `MessageQueue('rabbitmq', ...)` from `@rfcx/message-queue@1.1.0` (which already ships a RabbitMQ adapter with SQS-compatible semantics).
- `main-tasks.js`: 4-line selector based on `INGEST_CONSUMER_TYPE` env.
- `package.json`: bumps `@rfcx/message-queue` from `^1.0.8` to `^1.1.0`.

## Message payload shape

Preserved identical to the SQS message body the existing AWS S3 event notifications emit:

```json
{
  "Records": [{
    "eventName": "ObjectCreated:Put",
    "s3": {
      "bucket": { "name": "rfcx-ingest-production", "arn": "..." },
      "object": { "key": "<streamId>/<uploadId>.opus", "size": 168536 }
    }
  }]
}
```

This means the in-cluster `s3-cache` can publish triggers (WS6, separate work) using the same body shape that AWS S3 events emit, and the consumer code path is identical for both sources.

## Consumer semantics (matches SQS)

- Prefetch=1 (single in-flight per worker).
- Handler returns truthy → ack.
- Handler returns false or throws → nack-no-requeue → routes to `ingest-service-upload-production-dlq` via DLX.

## Env vars (new)

- `INGEST_CONSUMER_TYPE=amazon|rabbitmq` (default `amazon`).
- `RABBITMQ_INGEST_TRIGGER_QUEUE=<name>` (default `ingest-service-upload-production`; only used when type=rabbitmq).
- `RABBITMQ_URL=amqp://user:pass@host:port/` (read by `@rfcx/message-queue` rabbitmq client; only used when type=rabbitmq).

## Risk

Zero for production (`INGEST_CONSUMER_TYPE` unset → AWS SQS path unchanged). Behavior diverges only when the env var is explicitly set, which happens only on rfcx-local.

## Test plan

1. Merge to `staging` (AWS staging deploy is a no-op for this change).
2. PR `staging → master` (AWS prod no-op + rfcx-local deploys).
3. On rfcx-local: set `INGEST_CONSUMER_TYPE=rabbitmq` + `RABBITMQ_URL=...` in the ingest-service-tasks configmap/secret.
4. Publish a synthetic message to the queue and verify `ingest()` fires.
5. Then wire up the s3-cache publisher (WS6, separate PR in `rfcx/rfcx-local`).