### PR TITLE
ingest-service: configurable separate provider for the upload bucket

### DIFF
--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -311,11 +311,22 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
       }
     }
 
-    if (!loggerIgnoredErrors.includes(message)) {
-      await storage.copy(`${uploadBucket}/${fileStoragePath}`, errorBucket, fileStoragePath)
-      // create error log text file in the same bucket
-      const storageErrorFilePath = fileStoragePath.replace(path.extname(fileStoragePath), '.txt')
-      await storage.createFromData(errorBucket, storageErrorFilePath, `message: ${err.message}\n\nstack: ${err.stack}`)
+    // Optionally copy the failed upload + a .txt error log into a
+    // dedicated error bucket so ops can inspect failures. Disabled by
+    // default in v2 to avoid cross-provider server-side copy issues
+    // (the upload bucket may live on a different provider than the
+    // error bucket, in which case AWS-SDK CopyObject silently fails).
+    // Set ERROR_BUCKET_ENABLED=true to re-enable on environments
+    // where both buckets share a provider (e.g. AWS-prod legacy).
+    if (process.env.ERROR_BUCKET_ENABLED === 'true' && errorBucket && !loggerIgnoredErrors.includes(message)) {
+      try {
+        await storage.copy(`${uploadBucket}/${fileStoragePath}`, errorBucket, fileStoragePath)
+        // create error log text file in the same bucket
+        const storageErrorFilePath = fileStoragePath.replace(path.extname(fileStoragePath), '.txt')
+        await storage.createFromData(errorBucket, storageErrorFilePath, `message: ${err.message}\n\nstack: ${err.stack}`)
+      } catch (errOnErrorCopy) {
+        console.warn(`[${uploadId}] Failed to archive error blob to ${errorBucket}: ${errOnErrorCopy.message}`)
+      }
     }
 
     await storage.deleteObject(uploadBucket, fileStoragePath)

--- a/services/storage/amazon.js
+++ b/services/storage/amazon.js
@@ -3,17 +3,72 @@ const fs = require('fs')
 
 const uploadBucket = process.env.UPLOAD_BUCKET
 
-// rfcx-local fork: support an S3-compatible endpoint (MinIO, B2, R2,
-// in-cluster s3-cache, etc.) when AWS_S3_ENDPOINT is set. With it unset,
-// behavior is bit-identical to upstream: vanilla AWS S3.
-const _s3Config = {
-  signatureVersion: 'v4'
+// Build a configured AWS.S3 client. When an endpoint is set, the
+// client is wired for S3-compatible storage (MinIO, B2, R2, the
+// in-cluster s3-proxy/s3-writer, etc.); when unset, it talks to
+// vanilla AWS S3 with the global SDK config.
+//
+// Optional per-bucket credentials let the caller override the
+// global AWS_ACCESS_KEY_ID / AWS_SECRET_KEY / AWS_REGION_ID with a
+// scoped set of credentials. Useful when the upload bucket lives on
+// a different provider (e.g. Cloudflare R2) than the segment-write
+// bucket (e.g. B2 via the local s3-writer).
+function buildS3Client ({ endpoint, forcePathStyle, accessKeyId, secretAccessKey, region }) {
+  const config = {
+    signatureVersion: 'v4'
+  }
+  if (endpoint) {
+    config.endpoint = endpoint
+    config.s3ForcePathStyle = forcePathStyle === 'true' || forcePathStyle === true
+  }
+  // When any credential override is supplied, use it instead of the
+  // SDK-global creds. Otherwise (all undefined), the client picks up
+  // AWS_ACCESS_KEY_ID / AWS_SECRET_KEY / AWS_REGION_ID via
+  // AWS.config.update() in utils/aws.js.
+  if (accessKeyId || secretAccessKey || region) {
+    if (accessKeyId) { config.accessKeyId = accessKeyId }
+    if (secretAccessKey) { config.secretAccessKey = secretAccessKey }
+    if (region) { config.region = region }
+  }
+  return new AWS.S3(config)
 }
-if (process.env.AWS_S3_ENDPOINT) {
-  _s3Config.endpoint = process.env.AWS_S3_ENDPOINT
-  _s3Config.s3ForcePathStyle = process.env.AWS_S3_FORCE_PATH_STYLE === 'true'
+
+// Default client. Used for everything unless overridden below.
+// Reads AWS_S3_ENDPOINT + AWS_S3_FORCE_PATH_STYLE for endpoint config;
+// credentials come from utils/aws.js (AWS_ACCESS_KEY_ID etc.).
+const defaultClient = buildS3Client({
+  endpoint: process.env.AWS_S3_ENDPOINT,
+  forcePathStyle: process.env.AWS_S3_FORCE_PATH_STYLE
+})
+
+// Upload-bucket client (optional override). Used by:
+//   - getSignedUrl()  — issues device-facing PUT URLs.
+//   - download()      — tasks consumer fetches the audio blob.
+//   - any deleteObject(uploadBucket, ...) call.
+//
+// When UPLOAD_S3_ENDPOINT is unset, falls back to defaultClient so
+// behavior is bit-identical to the pre-override world. When set, the
+// upload bucket is served by a separate provider (e.g. Cloudflare R2)
+// and the device-facing signed URL hostname matches that endpoint.
+//
+// Independent credentials so an R2-only IAM key can be used here
+// without exposing R2 creds to the segment-write path.
+const uploadClient = process.env.UPLOAD_S3_ENDPOINT
+  ? buildS3Client({
+    endpoint: process.env.UPLOAD_S3_ENDPOINT,
+    forcePathStyle: process.env.UPLOAD_S3_FORCE_PATH_STYLE,
+    accessKeyId: process.env.UPLOAD_S3_ACCESS_KEY_ID,
+    secretAccessKey: process.env.UPLOAD_S3_SECRET_KEY,
+    region: process.env.UPLOAD_S3_REGION_ID
+  })
+  : defaultClient
+
+// Pick the right client for a given bucket. We key off the configured
+// UPLOAD_BUCKET name; everything else uses the default.
+function clientFor (bucket) {
+  if (bucket === uploadBucket) { return uploadClient }
+  return defaultClient
 }
-const s3Client = new AWS.S3(_s3Config)
 
 function getSignedUrl (filePath, contentType) {
   const params = {
@@ -23,7 +78,7 @@ function getSignedUrl (filePath, contentType) {
     ContentType: contentType
   }
   return (new Promise((resolve, reject) => {
-    s3Client.getSignedUrl('putObject', params, (err, data) => {
+    uploadClient.getSignedUrl('putObject', params, (err, data) => {
       if (err) {
         reject(err)
       } else {
@@ -36,13 +91,13 @@ function getSignedUrl (filePath, contentType) {
 function download (remotePath, localPath) {
   return new Promise((resolve, reject) => {
     try {
-      s3Client.headObject({
+      uploadClient.headObject({
         Bucket: uploadBucket,
         Key: remotePath
       }, (headErr, data) => {
         if (headErr) { reject(headErr) }
         const tempWriteStream = fs.createWriteStream(localPath)
-        const tempReadStream = s3Client.getObject({
+        const tempReadStream = uploadClient.getObject({
           Bucket: uploadBucket,
           Key: remotePath
         })
@@ -72,7 +127,7 @@ function upload (Bucket, remotePath, localPath) {
     Key: remotePath,
     Body: fileStream
   }
-  return s3Client.putObject(opts).promise()
+  return clientFor(Bucket).putObject(opts).promise()
 }
 
 function createFromData (Bucket, remotePath, data) {
@@ -81,11 +136,17 @@ function createFromData (Bucket, remotePath, data) {
     Key: remotePath,
     Body: data
   }
-  return s3Client.putObject(opts).promise()
+  return clientFor(Bucket).putObject(opts).promise()
 }
 
 /**
- * Copies one a file on S3
+ * Copies a file on S3.
+ *
+ * CopySource is "bucket/path"; the destination Bucket determines which
+ * client we use. Cross-provider server-side copy (e.g. R2 -> AWS) is
+ * not supported by AWS-SDK CopyObject — callers that need to move
+ * objects between providers should download + upload explicitly.
+ *
  * @param {*} CopySource Source path (including bucket)
  * @param {*} Bucket Destination bucket
  * @param {*} Key Destination path (excluding bucket)
@@ -94,12 +155,12 @@ function createFromData (Bucket, remotePath, data) {
  */
 function copy (CopySource, Bucket, Key, ContentType) {
   const opts = { Bucket, CopySource, Key, ContentType }
-  return s3Client.copyObject(opts).promise()
+  return clientFor(Bucket).copyObject(opts).promise()
 }
 
 function deleteObject (Bucket, Key) {
   const opts = { Bucket, Key }
-  return s3Client.deleteObject(opts).promise()
+  return clientFor(Bucket).deleteObject(opts).promise()
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

Adds an optional second S3 client for the upload bucket only, so the upload bucket can live on a different provider than the segment-write bucket.

## Why

Today `services/storage/amazon.js` uses a single AWS S3 client for both:
- **Upload bucket** (`UPLOAD_BUCKET`): where devices PUT raw audio via the pre-signed URL.
- **Segment bucket** (`INGEST_BUCKET`): where tasks write transcoded segments.

When those buckets live on different providers — which is exactly the rfcx-local case (upload bucket on Cloudflare R2 = `rfcx-ingest-r2`; segment bucket on B2 via `rfcx-streams-production` proxied through s3-writer) — a single client cannot serve both.

## Change

1. New `uploadClient` (separate `AWS.S3` instance) used by `getSignedUrl`, `download`, and any `deleteObject(uploadBucket, ...)`.
2. Configured via 5 optional env vars (all default to the existing `AWS_*` values):
   - `UPLOAD_S3_ENDPOINT`
   - `UPLOAD_S3_FORCE_PATH_STYLE`
   - `UPLOAD_S3_ACCESS_KEY_ID`
   - `UPLOAD_S3_SECRET_KEY`
   - `UPLOAD_S3_REGION_ID`
3. `clientFor(bucket)` routes `upload`, `createFromData`, `copy`, `deleteObject` to the right client based on bucket name.
4. **Error-bucket archive gated** behind `ERROR_BUCKET_ENABLED=true`. Default off, because the previous code did `storage.copy(uploadBucket/path, errorBucket, path)` — a cross-provider operation that silently fails when the upload bucket is on R2 and the error bucket is on AWS. Wrapped in try/catch so a failed archive can't mask the underlying ingestion error.

## Compatibility

When `UPLOAD_S3_ENDPOINT` is unset, `uploadClient` IS `defaultClient` — bit-identical to current code. **Zero behaviour change for AWS-prod** (all the new env vars unset there; `ERROR_BUCKET_ENABLED` set to `true` keeps the old archive flow).

## Risk

Zero for AWS-prod. For rfcx-local: the upload bucket switches to R2, but the segment-write path is untouched (still uses the default client → `AWS_S3_ENDPOINT=https://s3.arbimon.org` → s3-writer → B2). The `download()` path in tasks now reads from R2 — verified manually to work with the existing R2 IAM key we've been using for `r2-ingest` in s3-reader/s3-writer.

## Pre-existing test failures

`yarn jest` shows 4 failing tests in `services/audio.test.js` and `services/rfcx/ingest.test.js`. Verified by checking out `master` (pre-change) — same 4 fail there. These are env-setup / ffmpeg-binary-availability issues unrelated to this PR.

## Test plan post-deploy

Set on rfcx-local apps-prod `ingest-service-api`:
```
UPLOAD_BUCKET=rfcx-ingest-r2
UPLOAD_S3_ENDPOINT=https://<r2-account>.r2.cloudflarestorage.com
UPLOAD_S3_FORCE_PATH_STYLE=true
UPLOAD_S3_REGION_ID=auto
UPLOAD_S3_ACCESS_KEY_ID=<R2 IAM key>
UPLOAD_S3_SECRET_KEY=<R2 IAM secret>
```

Then:
1. `POST /uploads` from inside a pod → response `url` should be `https://<r2-account>.r2.cloudflarestorage.com/rfcx-ingest-r2/...`
2. PUT a synthetic file at that URL → 200 OK; object lands in R2.
3. (After Cloudflare R2 event notifications + webhook PR #652 are wired up) the R2 PUT event triggers ingest-service-tasks, which downloads from R2, transcodes, and writes the segment to B2.