### PR TITLE
ci(cd): remove AWS build+deploy jobs (kops decommissioned)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,29 +35,6 @@ jobs:
             echo "::set-output name=namespace::testing"
           fi
 
-  build:
-    name: 'Build'
-    needs: [prepare, configure]
-    uses: rfcx/cicd/.github/workflows/ecr-build-push.yaml@master
-    with:
-      dockerfile: build/Dockerfile
-      targets: "[\"ingest-service\"]"
-      tag-environment: ${{ needs.configure.outputs.namespace }}
-      tag-latest: ${{ needs.configure.outputs.namespace == 'production' }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  deploy:
-    name: 'Deploy'
-    needs: [build, configure]
-    uses: rfcx/cicd/.github/workflows/k8s-deploy.yaml@master
-    with:
-      tag: ${{ needs.build.outputs.unique-tag }}
-      namespace: ${{ needs.configure.outputs.namespace }}
-    secrets:
-      kube-config: ${{ secrets.KUBE_CONFIG_SUPER }}
-
   deploy-rfcx-local:
     name: 'Deploy: rfcx-local'
     needs: [prepare, configure]
@@ -77,17 +54,17 @@ jobs:
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [prepare, build, deploy, deploy-rfcx-local]
+    needs: [prepare, deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify-send.yaml@master
     with:
       repo: ingest-service
       branch-name: ${{ needs.prepare.outputs.branch-name }}
       workflow-id: cd.yaml
       previous-run-id: ${{ needs.prepare.outputs.previous-run-id }}
-      status: ${{ needs.deploy.result }}
+      status: ${{ needs.deploy-rfcx-local.result }}
       always: true
       notification-title: 'CD: Ingest Service'
-      notification-footer: "Build: ${{ needs.build.result || 'n/a' }} | Deploy: ${{ needs.deploy.result || 'n/a' }}"
+      notification-footer: "Deploy (rfcx-local): ${{ needs.deploy-rfcx-local.result || 'n/a' }}"
       notification-success-statement: '{0} deployed the build!'
     secrets:
       slack-webhook: ${{ secrets.SLACK_ALERT_COREDT_WEBHOOK }}


### PR DESCRIPTION
## Summary

Removes the AWS-targeted `build:` (ECR push) and `deploy:` (kops `kubectl apply`) jobs from this repo's `cd.yaml`. The kops production cluster has been declared dead by the operator (2026-05-18 18:55 EDT), and rfcx-local is now the sole production deploy target.

## Background

- **Phase 3 (2026-05-18 18:55 EDT)** moved the device-upload data plane entirely off AWS — see `evity-squibbon/rfcx-local`'s `STATE.md` "Phase 3 Status" + "AWS / kops decommission status" blocks.
- All kops Mandrill keys revoked; staging/prediction/arbimon-jobs-staging namespaces deleted.
- The AWS `build:` and `deploy:` jobs in this workflow either fail noisily (most recent run on rfcx-api) or, once `KUBE_CONFIG_SUPER` rotates / kops gets torn down, will fail uniformly. They have no useful behaviour going forward.
- The `deploy-rfcx-local:` job (added 2026-05-16) does its own in-cluster arm64 build via the self-hosted runner in the rfcx-local cluster's `cicd` namespace, pushes to the in-cluster registry at `192.168.5.1:30500`, and rolls `apps-prod` Deployments via the runner's RBAC. It has zero dependency on the AWS jobs.

## What changes

In `.github/workflows/cd.yaml`:

- **Removed** `build:` job (uses `rfcx/cicd/.github/workflows/ecr-build-push.yaml@master`)
- **Removed** `deploy:` job (uses `rfcx/cicd/.github/workflows/k8s-deploy.yaml@master`)
- **Updated** `notify.needs:` to depend only on `[prepare, deploy-rfcx-local]`
- **Updated** notify `status` to report `deploy-rfcx-local.result`
- **Updated** notify `notification-footer` to surface only the rfcx-local result

`prepare:` and `configure:` are kept (still needed for `deploy-rfcx-local`'s `if: namespace == 'production'` gate and for notify metadata). `staging` is left in `on.push.branches` (no-op on staging push — `deploy-rfcx-local` is gated to production — but preserves the staging-promotion PR mechanism).

## What's unchanged

`deploy-rfcx-local:` is byte-identical. So is `concurrency:`. No new secrets, no removed inputs.

## Validation plan

- Push to `staging` first (via this PR landing): runs `prepare → configure`, skips `deploy-rfcx-local` (namespace=staging). Should complete successfully with no AWS calls.
- Once merged to `master` via the companion `staging → master` PR: triggers the rfcx-local CD path only. Should match recent successful runs.

## Rollback

Revert this PR. The AWS jobs come back. Note: this only restores the workflow definition — kops production itself is dead regardless, so the AWS jobs will fail until kops comes back (which is not the plan).

## Related

- `evity-squibbon/rfcx-local` PR / branch: `agent/ms4-strip-aws-cd-20260519` (this same branch name across all 7 rfcx-org repos this week).
- Companion PRs in `rfcx/{rfcx-api, ingest-service, guardian-api, guardian-dashboard, arbimon, arbimon-legacy}`.