### PR TITLE
Promote staging -> master (AWS CD-strip + feat PRs)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,29 +35,6 @@ jobs:
             echo "::set-output name=namespace::testing"
           fi
 
-  build:
-    name: 'Build'
-    needs: [prepare, configure]
-    uses: rfcx/cicd/.github/workflows/ecr-build-push.yaml@master
-    with:
-      dockerfile: build/Dockerfile
-      targets: "[\"ingest-service\"]"
-      tag-environment: ${{ needs.configure.outputs.namespace }}
-      tag-latest: ${{ needs.configure.outputs.namespace == 'production' }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  deploy:
-    name: 'Deploy'
-    needs: [build, configure]
-    uses: rfcx/cicd/.github/workflows/k8s-deploy.yaml@master
-    with:
-      tag: ${{ needs.build.outputs.unique-tag }}
-      namespace: ${{ needs.configure.outputs.namespace }}
-    secrets:
-      kube-config: ${{ secrets.KUBE_CONFIG_SUPER }}
-
   deploy-rfcx-local:
     name: 'Deploy: rfcx-local'
     needs: [prepare, configure]
@@ -77,17 +54,17 @@ jobs:
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [prepare, build, deploy, deploy-rfcx-local]
+    needs: [prepare, deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify-send.yaml@master
     with:
       repo: ingest-service
       branch-name: ${{ needs.prepare.outputs.branch-name }}
       workflow-id: cd.yaml
       previous-run-id: ${{ needs.prepare.outputs.previous-run-id }}
-      status: ${{ needs.deploy.result }}
+      status: ${{ needs.deploy-rfcx-local.result }}
       always: true
       notification-title: 'CD: Ingest Service'
-      notification-footer: "Build: ${{ needs.build.result || 'n/a' }} | Deploy: ${{ needs.deploy.result || 'n/a' }}"
+      notification-footer: "Deploy (rfcx-local): ${{ needs.deploy-rfcx-local.result || 'n/a' }}"
       notification-success-statement: '{0} deployed the build!'
     secrets:
       slack-webhook: ${{ secrets.SLACK_ALERT_COREDT_WEBHOOK }}

--- a/main-all.js
+++ b/main-all.js
@@ -3,6 +3,8 @@ if (process.env.NODE_ENV === 'production') {
 }
 require('dotenv').config()
 
+require('./utils/process-handlers').installProcessHandlers('ingest-service-all')
+
 console.info('API and Tasks: starting')
 
 const api = require('./routes')

--- a/main-api.js
+++ b/main-api.js
@@ -4,6 +4,8 @@ if (process.env.NODE_ENV === 'production') {
 }
 require('dotenv').config()
 
+require('./utils/process-handlers').installProcessHandlers('ingest-service-api')
+
 console.info('API: starting')
 require('./utils/mongo')
 const api = require('./routes')

--- a/main-tasks.js
+++ b/main-tasks.js
@@ -1,5 +1,7 @@
 require('dotenv').config()
 
+require('./utils/process-handlers').installProcessHandlers('ingest-service-tasks')
+
 console.info('Tasks: starting')
 require('./utils/mongo')
 const api = require('./routes/index-tasks')

--- a/middleware/error.js
+++ b/middleware/error.js
@@ -7,6 +7,18 @@ function notFound (req, res, next) {
 function exceptionOccurred (err, req, res, next) {
   const status = err.status || 500
   console.error('Express.js error handler', { req: req.guid, url: req.url, status: status, err: err })
+
+  // If the response has already started streaming (e.g. a download
+  // route emitted data via `request.get(...).pipe(res)` and then the
+  // upstream errored mid-stream), we MUST NOT try to set headers
+  // again — `res.status(...).json(...)` would throw a synchronous
+  // ERR_HTTP_HEADERS_SENT, escape Express, become an uncaught
+  // exception, and crash the process. Delegate to Express's default
+  // finalhandler which closes the connection cleanly.
+  if (res.headersSent) {
+    return next(err)
+  }
+
   res.status(status).json({
     message: err.message,
     error: err

--- a/middleware/error.test.js
+++ b/middleware/error.test.js
@@ -1,0 +1,82 @@
+const { exceptionOccurred, notFound } = require('./error')
+
+function mockReq (overrides = {}) {
+  return Object.assign({ guid: 'r-123', url: '/test' }, overrides)
+}
+
+function mockRes (overrides = {}) {
+  const res = {
+    statusCode: 200,
+    headersSent: false,
+    _jsonBody: undefined,
+    status (code) { this.statusCode = code; return this },
+    json (body) { this._jsonBody = body; return this }
+  }
+  return Object.assign(res, overrides)
+}
+
+describe('middleware/error', () => {
+  let consoleErrorSpy
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  describe('notFound', () => {
+    test('produces a 404 error and forwards via next', () => {
+      const next = jest.fn()
+      notFound(mockReq(), mockRes(), next)
+      expect(next).toHaveBeenCalledTimes(1)
+      const err = next.mock.calls[0][0]
+      expect(err).toBeInstanceOf(Error)
+      expect(err.message).toBe('Not Found')
+      expect(err.status).toBe(404)
+    })
+  })
+
+  describe('exceptionOccurred', () => {
+    test('sends a JSON error response when headers have not been sent', () => {
+      const res = mockRes()
+      const next = jest.fn()
+      const err = new Error('boom')
+
+      exceptionOccurred(err, mockReq(), res, next)
+
+      expect(res.statusCode).toBe(500)
+      expect(res._jsonBody).toEqual({ message: 'boom', error: err })
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    test('honors err.status', () => {
+      const res = mockRes()
+      const err = Object.assign(new Error('nope'), { status: 422 })
+
+      exceptionOccurred(err, mockReq(), res, jest.fn())
+
+      expect(res.statusCode).toBe(422)
+    })
+
+    test('does NOT throw or set headers when res.headersSent is true; delegates to next', () => {
+      // Simulate the Squirrel-update / nuts-serve scenario: a download
+      // route already piped bytes to the client (so headersSent=true),
+      // then upstream errored. The error middleware must not try to
+      // set headers again — that would synchronously throw
+      // ERR_HTTP_HEADERS_SENT and crash the process.
+      const res = mockRes({
+        headersSent: true,
+        status () { throw new Error('ERR_HTTP_HEADERS_SENT: should not be called') },
+        json () { throw new Error('ERR_HTTP_HEADERS_SENT: should not be called') }
+      })
+      const next = jest.fn()
+      const err = new Error('upstream pipe failed')
+
+      expect(() => exceptionOccurred(err, mockReq(), res, next)).not.toThrow()
+      expect(next).toHaveBeenCalledTimes(1)
+      expect(next).toHaveBeenCalledWith(err)
+    })
+  })
+})

--- a/utils/process-handlers.js
+++ b/utils/process-handlers.js
@@ -1,0 +1,38 @@
+// Last-resort process-level handlers.
+//
+// Express's error middleware should always be the first line of
+// defence, but bugs that throw *after* `res.headersSent` (e.g. a
+// `res.status(...).json(...)` inside the error handler while a
+// download response is already streaming) escape Express entirely
+// and become an `uncaughtException`. Without a handler, Node logs a
+// terse stack and exits with code 1, taking the pod with it. With a
+// handler we at least leave a structured log line behind so the
+// next operator can identify the offending route in seconds rather
+// than minutes.
+//
+// We do NOT swallow the error — best practice is still to exit on
+// uncaughtException because the process state is undefined. We just
+// add diagnostic context first.
+
+function installProcessHandlers (label) {
+  process.on('uncaughtException', (err, origin) => {
+    console.error('Uncaught exception (will exit)', {
+      service: label,
+      origin,
+      message: err && err.message,
+      stack: err && err.stack
+    })
+    process.exit(1)
+  })
+
+  process.on('unhandledRejection', (reason) => {
+    console.error('Unhandled promise rejection', {
+      service: label,
+      message: reason && reason.message,
+      stack: reason && reason.stack,
+      reason: typeof reason === 'object' ? undefined : reason
+    })
+  })
+}
+
+module.exports = { installProcessHandlers }


### PR DESCRIPTION
## Summary

Promotes `staging` → `master` (production). Carries the AWS CD-strip + any feature PRs that landed on staging in this cycle.

## Contents

Per `gh api compare master...staging` at PR-open time — see commit list on this PR for the authoritative set. Expected high-level changes:

1. **AWS `build:`/`deploy:` jobs removed from `cd.yaml`** (kops decommissioned per operator decision 2026-05-18 18:55 EDT). `deploy-rfcx-local:` is the sole CD path going forward. Workflow now: `prepare → configure → deploy-rfcx-local → notify`.

2. **For `rfcx-api`**: also carries [#654](https://github.com/rfcx/rfcx-api/pull/654) — optional Sequelize PG read-replica routing with weighted read pool (env-gated via `POSTGRES_REPLICA_HOSTNAME`; no-op when unset).

3. **For `ingest-service`**: also carries [#92](https://github.com/rfcx/ingest-service/pull/92) — `res.headersSent` early-return + structured `uncaughtException`/`unhandledRejection` handlers.

## What happens on merge

CD triggers immediately on push to `master`:
- `prepare → configure → deploy-rfcx-local (namespace=production)` 
- The runner builds each target stage with `docker buildx --platform linux/arm64`, pushes to `192.168.5.1:30500/<image>:rfcx-local-prod-<short-sha>`
- `kubectl set image` rolls each apps-prod Deployment named in the workflow's `deployments:` list
- `kubectl rollout status --timeout=180s` per deployment

## Rollback

Standard chain: revert this PR (creates a counter-promotion), then push it through. Or revert the originating commits on `master` and roll the previous image tag back via `kubectl -n apps-prod set image deploy/<name> <container>=192.168.5.1:30500/<image>:<prev-rfcx-local-prod-sha>`.

## Related

- Companion `staging → master` PRs across the rfcx-org sweep.
- `evity-squibbon/rfcx-local` STATE.md "AWS / kops decommission status" block.