### PR TITLE
fix(arbimon-upload-limit): treat 404 from biodiversity-api as unlimited

### DIFF
--- a/services/rfcx/arbimon.js
+++ b/services/rfcx/arbimon.js
@@ -12,7 +12,27 @@ function getProjectUploadLimitSummary (idToken, projectId) {
 
   return axios.get(url, { headers })
     .then(response => response.data)
-    .catch(e => { throw matchAxiosErrorToRfcx(e) })
+    .catch(e => {
+      // Graceful degradation: if the project's upload-limit endpoint isn't
+      // available (404 — the route is in biodiversity-api 'develop' but not
+      // yet in 'master', so the deployed image may not have it; or the
+      // project doesn't exist in biodiversity-api's DB at all), treat the
+      // project as having NO upload limit configured. This matches the
+      // semantics of `recordingMinutesLimit: null` further up the call
+      // chain (assertProjectUploadWithinLimit in routes/uploads.js).
+      //
+      // The check exists to refuse uploads to view-only / over-quota
+      // projects; missing endpoint is interpreted as 'no quota information
+      // available, allow the upload'. The alternative (failing closed)
+      // breaks all uploads when the dependency is out of sync, which is
+      // both worse user experience and was the production behavior on
+      // 2026-05-19 immediately after the Phase 3 ingest cutover landed.
+      if (e && e.response && e.response.status === 404) {
+        console.warn('[arbimon] upload-limit-summary endpoint returned 404 for project ' + projectId + '; treating as unlimited.')
+        return { isLocked: false, recordingMinutesLimit: null, recordingMinutesCount: 0 }
+      }
+      throw matchAxiosErrorToRfcx(e)
+    })
 }
 
 module.exports = {


### PR DESCRIPTION
## Bug

Every device-upload `POST /uploads` failed in rfcx-local apps-prod (and would also fail on AWS-prod kops, except its ingest-service-api is scaled to 0 after the 2026-05-18 cutover). The user-facing error was either:

- `400 Missing required parameters ValidationError` — from the express error handler defaulting to ValidationError when no `headersSent` mapping fires (#92 in this repo fixes that misdirection).
- `500 Request failed with status code 500` — once the upstream stopped 429ing and started 404ing.

## Root cause

`assertProjectUploadWithinLimit` in `routes/uploads.js` calls `arbimonService.getProjectUploadLimitSummary(idToken, projectId)`, which hits `${ARBIMON_HOST}/projects-core/<id>/upload-limit-summary` on biodiversity-api.

The route `/projects-core/:idCore/upload-limit-summary` is in [`rfcx/arbimon`](https://github.com/rfcx/arbimon) on the `develop` branch but **not yet on `master`**. Both AWS-prod and rfcx-local deploy biodiversity-api from `master`, so the endpoint 404s for every project.

The 404 bubbled up as an unhandled axios error, broke the upload pipeline.

## Fix

`services/rfcx/arbimon.js`: when `getProjectUploadLimitSummary` gets a 404, return a 'no limit configured' summary (`{isLocked: false, recordingMinutesLimit: null, recordingMinutesCount: 0}`). That matches the semantics of `recordingMinutesLimit: null` further up the call chain, so the upload proceeds normally.

Other axios errors (network, 5xx, auth) still throw — only 404 is treated as 'feature not deployed yet, fail open'.

Adds a `console.warn` so the operator can see when the fallback path fires; once biodiversity-api ships the matching handler to master, the warn will stop and the limit check will work as intended.

## Verified

- `yarn lint` clean
- Manual curl reproduces the 404; after this patch, the upload-limit-summary call resolves and the upload proceeds.

## Risk

Tiny. The check exists to refuse uploads to view-only / over-quota projects. **Failing open on missing endpoint** is the same behavior as before the check was introduced; **failing closed** breaks all uploads system-wide, which is what we observed.

## Related

- #92 fixes the misleading `Missing required parameters ValidationError` that masked this root cause.