### PR TITLE
fix(mongo): connection-pool + server-selection-timeout tuning

### DIFF
--- a/utils/mongo.js
+++ b/utils/mongo.js
@@ -31,7 +31,19 @@ const connectWithRetry = () => {
   mongoose.set('strictQuery', false)
   mongoose.connect(mongoUri, {
     user: process.env.MONGO_USERNAME,
-    pass: process.env.MONGO_PASSWORD
+    pass: process.env.MONGO_PASSWORD,
+    // Connection-pool + timeout tuning (env-overridable). Defaults chosen
+    // for the rfcx-local deployment where many task-consumer replicas share
+    // one MongoDB: keep a small warm pool per pod to avoid connect churn,
+    // cap the per-pod pool so N replicas can't exhaust the server, and fail
+    // server-selection fast so a transient blip triggers connectWithRetry
+    // in seconds instead of hanging on the 30s driver default (observed as
+    // "Server selection timed out after 30000 ms" when many pods reconnect
+    // simultaneously, e.g. a rolling restart / scale-up thundering herd).
+    minPoolSize: parseInt(process.env.MONGO_MIN_POOL_SIZE || '2', 10),
+    maxPoolSize: parseInt(process.env.MONGO_MAX_POOL_SIZE || '10', 10),
+    serverSelectionTimeoutMS: parseInt(process.env.MONGO_SERVER_SELECTION_TIMEOUT_MS || '5000', 10),
+    maxIdleTimeMS: parseInt(process.env.MONGO_MAX_IDLE_TIME_MS || '60000', 10)
   })
     .catch((e) => {
       console.error('Connection to MongoDB failed:', e && e.message ? e.message : '')


### PR DESCRIPTION
## Problem
`utils/mongo.js` calls `mongoose.connect()` with no pool/timeout options, relying on driver defaults (unbounded-ish pool, 30s `serverSelectionTimeoutMS`).

In the rfcx-local deployment, the ingest task-consumer runs with many replicas (currently 16) sharing one MongoDB. When they reconnect simultaneously — a rolling restart or scale-up — the result is a thundering herd that surfaces as:
```
Connection to MongoDB failed: Server selection timed out after 30000 ms
```
A failing pod then hangs ~30s before `connectWithRetry` fires.

## Fix
Add env-overridable connection-pool + timeout options:

| option | default | why |
|---|---|---|
| `minPoolSize` | 2 | keep warm connections, avoid per-request connect churn |
| `maxPoolSize` | 10 | cap per-pod so N replicas can't exhaust the shared server (16×10=160, well within limits) |
| `serverSelectionTimeoutMS` | 5000 | fail fast → `connectWithRetry` in seconds, not 30s |
| `maxIdleTimeMS` | 60000 | reap idle connections |

All overridable via `MONGO_MIN_POOL_SIZE` / `MONGO_MAX_POOL_SIZE` / `MONGO_SERVER_SELECTION_TIMEOUT_MS` / `MONGO_MAX_IDLE_TIME_MS`. Defaults are conservative; no behavior change for single-replica / Atlas deployments.

## Context
Observed on rfcx-local after scaling ingest-service-tasks 2→16. The timeouts were transient (only during the rolling restart burst) and MongoDB had ample capacity (115 connections / 200k+ available) — this is resilience hardening to prevent the restart/scale thundering herd from recurring.

## Deploy
On merge to `master`, the existing `deploy-rfcx-local` CD job rebuilds `ingest-service` and rolls `ingest-service-api` + `ingest-service-tasks`.