### PR TITLE
feat(ingest): pre-transcode checksum dedup (skip already-ingested before transcode)

### DIFF
--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -232,6 +232,37 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
     console.info(`[${uploadId}] Upload metadata from database `, JSON.stringify(upload))
     validateAudioMeta(upload, fileData, fileExtension)
 
+    // Pre-transcode duplicate check (optimization). The original-file sha1
+    // (fileData.checksum) is known here, before the expensive transcode +
+    // 60-segment upload. If Core already has a stream source file with this
+    // sha1 at this timestamp, the file was already ingested -> skip straight
+    // to the duplicate outcome (the catch block marks status + deletes the
+    // R2 source + acks). This is a perf optimization only; the authoritative
+    // dedup remains the post-transcode createStreamFileData call below, which
+    // also guards the concurrent-worker race (two workers may both pass this
+    // pre-check before either has created the source file).
+    // Apply the SAME duplicate test as the upload API's pre-upload check
+    // (routes/uploads.js): an existing source file matched by sha1 + start,
+    // that already has segments whose first segment start equals this
+    // timestamp (within 1s) and is available (availability !== 0), is a
+    // genuine already-ingested duplicate. (availability === 0 means the
+    // existing file was deleted/unavailable, so a re-ingest is allowed --
+    // we must NOT skip in that case.) Only skip the transcode on a true dup;
+    // the post-transcode createStreamFileData call remains authoritative.
+    const existingSrc = await segmentService.findIngestedDuplicate(
+      upload.streamId, fileData.checksum, moment.tz(upload.timestamp, 'UTC')
+    )
+    if (existingSrc && existingSrc.id) {
+      const ts = moment.tz(upload.timestamp, 'UTC').valueOf()
+      const hasSegments = existingSrc.segments && existingSrc.segments.length
+      const sameFile = hasSegments && Math.abs(moment.utc(existingSrc.segments[0].start).valueOf() - ts) < 1000
+      if (sameFile && existingSrc.availability !== 0) {
+        console.info(`[${uploadId}] Pre-transcode dedup: sha1 already ingested (source_file ${existingSrc.id}); skipping transcode`)
+        throw new IngestionError('Duplicate file. Matching sha1 signature already ingested.', db.status.DUPLICATE)
+      }
+    }
+    tracker.logAndSetNewPoint(`[${uploadId}] pre-transcode dedup check`)
+
     console.info(`[${uploadId}] Transcoding file`)
     tracker.setPoint()
     const transcodeData = await transcode(fileLocalPath, fileData)

--- a/services/rfcx/segments.js
+++ b/services/rfcx/segments.js
@@ -44,27 +44,24 @@ async function findIngestedDuplicate (stream, checksum, timestamp) {
   if (!checksum) {
     return null
   }
-  const url = `${apiHostName}internal/ingest/streams/${stream}/stream-source-file`
-  const token = await auth0Service.getToken()
-  const params = {
-    sha1_checksum: checksum,
-    start: (timestamp && timestamp.toISOString) ? timestamp.toISOString() : timestamp
-  }
-  const headers = {
-    Authorization: `Bearer ${token.access_token}`,
-    'Content-Type': 'application/json'
-  }
+  // Entire body (incl. token fetch) is guarded: this is a best-effort
+  // optimization, so ANY failure (auth, network, not-found) must return
+  // null and never block ingestion. The authoritative post-transcode
+  // createStreamFileData dedup is the real guarantee.
   try {
+    const url = `${apiHostName}internal/ingest/streams/${stream}/stream-source-file`
+    const token = await auth0Service.getToken()
+    const params = {
+      sha1_checksum: checksum,
+      start: (timestamp && timestamp.toISOString) ? timestamp.toISOString() : timestamp
+    }
+    const headers = {
+      Authorization: `Bearer ${token.access_token}`,
+      'Content-Type': 'application/json'
+    }
     const response = await axios.get(url, { headers, params })
     return response && response.data ? response.data : null
   } catch (e) {
-    const rfcxErr = matchAxiosErrorToRfcx(e)
-    // "Stream source file not found" => genuinely not a duplicate.
-    if (rfcxErr && /not found/i.test(rfcxErr.message || '')) {
-      return null
-    }
-    // Any other error: don't block ingestion on a flaky pre-check; let the
-    // authoritative post-transcode createStreamFileData dedup catch it.
     return null
   }
 }

--- a/services/rfcx/segments.js
+++ b/services/rfcx/segments.js
@@ -26,6 +26,49 @@ function getExistingSourceFile (opts) {
     .catch(e => { throw matchAxiosErrorToRfcx(e) })
 }
 
+/**
+ * Pre-transcode duplicate check. Looks up an existing stream source file by
+ * (stream, sha1_checksum, start-timestamp) in Core. Unlike getExistingSourceFile
+ * this fetches its own auth token (like createStreamFileData) so the task
+ * consumer can call it directly after ffmpeg-identify and BEFORE transcoding,
+ * to skip the expensive transcode + segment-upload when the original file was
+ * already ingested. Returns the existing source file object on a match, or
+ * null if not found. Non-404 errors propagate (caller decides; we let the
+ * authoritative post-transcode createStreamFileData check be the backstop).
+ *
+ * @param {string} stream     stream id
+ * @param {string} checksum   sha1 of the ORIGINAL file (fileData.checksum)
+ * @param {Date|moment} timestamp  upload timestamp
+ */
+async function findIngestedDuplicate (stream, checksum, timestamp) {
+  if (!checksum) {
+    return null
+  }
+  const url = `${apiHostName}internal/ingest/streams/${stream}/stream-source-file`
+  const token = await auth0Service.getToken()
+  const params = {
+    sha1_checksum: checksum,
+    start: (timestamp && timestamp.toISOString) ? timestamp.toISOString() : timestamp
+  }
+  const headers = {
+    Authorization: `Bearer ${token.access_token}`,
+    'Content-Type': 'application/json'
+  }
+  try {
+    const response = await axios.get(url, { headers, params })
+    return response && response.data ? response.data : null
+  } catch (e) {
+    const rfcxErr = matchAxiosErrorToRfcx(e)
+    // "Stream source file not found" => genuinely not a duplicate.
+    if (rfcxErr && /not found/i.test(rfcxErr.message || '')) {
+      return null
+    }
+    // Any other error: don't block ingestion on a flaky pre-check; let the
+    // authoritative post-transcode createStreamFileData dedup catch it.
+    return null
+  }
+}
+
 function transformStreamSourceFilePayload (data) {
   return {
     filename: data.filename,
@@ -126,6 +169,7 @@ async function deleteStreamSourceFile (stream, payload) {
 
 module.exports = {
   getExistingSourceFile,
+  findIngestedDuplicate,
   createStreamFileData,
   deleteStreamSourceFile
 }


### PR DESCRIPTION
## Summary
Add a **pre-transcode** duplicate check so an already-ingested file is skipped *before* the expensive transcode + 60-segment upload, instead of only being caught afterward.

## Background
Today the only dedup is **post-transcode**: `createStreamFileData` (Core) rejects a duplicate by sha1, but only *after* the task has downloaded **and transcoded** the file and split it into segments (~71s + 60 segment writes for a 1h file). For duplicate-heavy workloads — especially DLQ / orphaned-upload re-drives — that's a large amount of wasted transcode + object-store I/O.

The original-file sha1 (`fileData.checksum`) is already computed right after `audioService.identify()`, **before** transcode, and Core persists it as `stream_source_files.sha1_checksum`. So we can check for a duplicate at that point.

## Change
- New `segmentService.findIngestedDuplicate(stream, checksum, timestamp)` — queries Core `GET /internal/ingest/streams/{stream}/stream-source-file?sha1_checksum=&start=`, self-fetching its auth token (like `createStreamFileData`). Returns `null` on not-found or any lookup error (never block ingestion on a flaky pre-check).
- In `ingest()`, after `validateAudioMeta` and before `transcode`: if a genuine duplicate exists (has segments, first-segment start within 1s of the upload timestamp, `availability !== 0` — the **same test** the upload API uses pre-upload in `routes/uploads.js`), throw `IngestionError('Duplicate file. Matching sha1 signature already ingested.', DUPLICATE)`. The existing catch path marks the upload, deletes the R2 source, and acks.

## Why keep the post-transcode check too
Intentionally **not** removing the post-transcode `createStreamFileData` dedup — it's the authoritative, atomic check at insert time and guards the **concurrent-worker race** (with N task replicas, two workers can both pass the pre-check before either creates the source file). The pre-check is a *performance optimization*; the post-check remains the *correctness* guarantee.

## Cost/benefit
- Still **downloads** the file (required to compute the checksum) — ~30-48s.
- **Skips** transcode + 60-segment object-store writes (~the bulk of per-recording cost, ~2-3 min) on a true duplicate.

## Context
rfcx-local: surfaced while planning a re-drive of orphaned `status=0` uploads (tens of thousands), many of which are already ingested. This makes re-driving cheap (download-only for dups) and is generally useful.