### PR TITLE
ingest: auto-reconnect RabbitMQ consumer (fix silent-stalled-consumer on broker blip)

### DIFF
--- a/main-all.js
+++ b/main-all.js
@@ -16,7 +16,12 @@ async function main () {
   })
 
   const ingestConsumer = require('./services/consumer/amazon')
-  ingestConsumer.start()
+  // Safety net: exit (so k8s restarts) rather than leaving the pod
+  // running-but-not-consuming if the consumer fails to start.
+  await ingestConsumer.start()
 }
 
-main()
+main().catch((e) => {
+  console.error('ingest-service-all main() failed; exiting for restart', e && e.message)
+  process.exit(1)
+})

--- a/main-tasks.js
+++ b/main-tasks.js
@@ -16,4 +16,13 @@ api.listen(port, () => {
 //   INGEST_CONSUMER_TYPE=rabbitmq (rfcx-local; RabbitMQ trigger)
 const consumerType = process.env.INGEST_CONSUMER_TYPE || 'amazon'
 const ingestConsumer = require(`./services/consumer/${consumerType}`)
-ingestConsumer.start()
+// Safety net: start() now self-heals (reconnect-with-backoff), but if it ever
+// rejects fatally, exit so kubernetes restarts the pod instead of leaving it
+// running-but-not-consuming (the silent-stalled-consumer bug). Previously this
+// call was unguarded, so a RabbitMQ blip became an unhandledRejection that the
+// process-handler logs but does NOT exit on — the pod looked healthy with 0
+// consumers attached and the queue stalled.
+ingestConsumer.start().catch((e) => {
+  console.error('Ingest consumer failed to start; exiting for restart', e && e.message)
+  process.exit(1)
+})

--- a/services/consumer/rabbitmq.js
+++ b/services/consumer/rabbitmq.js
@@ -80,28 +80,57 @@ async function handleMessage (body) {
 // Instead, we use checkQueue (passive declare): it fails if
 // the queue does not exist, but does not conflict with the
 // existing arguments. The publisher side has the same rule.
-async function start () {
-  if (!url) {
-    throw new Error('RABBITMQ_URL (or AMQP_URL) env var must be set when INGEST_CONSUMER_TYPE=rabbitmq')
+// Reconnect tuning (env-overridable). Backoff grows linearly per attempt up
+// to a cap, so a brief RabbitMQ blip recovers in seconds while a longer outage
+// doesn't hammer the broker.
+const RECONNECT_BASE_MS = parseInt(process.env.RABBITMQ_RECONNECT_BASE_MS || '2000', 10)
+const RECONNECT_MAX_MS = parseInt(process.env.RABBITMQ_RECONNECT_MAX_MS || '30000', 10)
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Establish ONE connection + channel + consumer. Resolves once the consumer is
+// subscribed; rejects if any step fails (so connectWithRetry can retry). On a
+// LATER drop (connection/channel 'close' after we were subscribed) we trigger a
+// fresh reconnect loop instead of process.exit(1): a RabbitMQ restart otherwise
+// crash-loops the whole consumer fleet AND (the bug this fixes) the INITIAL
+// connect failure used to become an unhandled rejection that left the pod up
+// but silently NOT consuming (looked healthy, queue stalled at 0 consumers).
+async function connectOnce () {
+  let reconnecting = false
+  const scheduleReconnect = (why) => {
+    if (reconnecting) { return }
+    reconnecting = true
+    console.error(`Ingest RabbitMQ ${why}; reconnecting...`)
+    // Detach from the current (dead) connection and start a fresh retry loop.
+    connectWithRetry().catch((e) => {
+      console.error('Ingest RabbitMQ reconnect loop failed fatally; exiting', e && e.message)
+      process.exit(1)
+    })
   }
+
   const connection = await amqplib.connect(url)
   connection.on('error', (err) => {
     console.error('Ingest RabbitMQ connection error', err && err.message)
   })
-  connection.on('close', () => {
-    console.error('Ingest RabbitMQ connection closed; exiting so kubernetes can restart us')
-    process.exit(1)
-  })
-  const channel = await connection.createChannel()
-  channel.on('error', (err) => {
-    console.error('Ingest RabbitMQ channel error', err && err.message)
-  })
-  channel.on('close', () => {
-    console.error('Ingest RabbitMQ channel closed; exiting so kubernetes can restart us')
-    process.exit(1)
-  })
-  await channel.checkQueue(queueName) // passive; fails if not pre-declared
-  await channel.prefetch(1)
+  connection.on('close', () => scheduleReconnect('connection closed'))
+  let channel
+  try {
+    channel = await connection.createChannel()
+    channel.on('error', (err) => {
+      console.error('Ingest RabbitMQ channel error', err && err.message)
+    })
+    channel.on('close', () => scheduleReconnect('channel closed'))
+    await channel.checkQueue(queueName) // passive; fails if not pre-declared
+    await channel.prefetch(1)
+  } catch (e) {
+    // Channel/queue setup failed on an otherwise-open connection: close it so we
+    // don't leak connections across retries (the 'close' handler is suppressed
+    // by re-throwing before any successful subscribe, so connectWithRetry owns
+    // the retry). Guard close() since it can itself throw if already dead.
+    reconnecting = true // prevent the close handler from double-scheduling
+    try { await connection.close() } catch (_) { /* already closing/closed */ }
+    throw e
+  }
   await channel.consume(queueName, async (msg) => {
     if (msg === null) { return } // consumer cancelled by server
     let body
@@ -125,6 +154,34 @@ async function start () {
     }
   })
   console.info(`Ingest RabbitMQ consumer subscribed to queue "${queueName}"`)
+}
+
+// Retry connectOnce() with capped linear backoff until it succeeds. This is the
+// core of the fix: neither the initial connect nor a later drop can leave the
+// pod running-but-not-consuming. (Liveness is still bounded by the fatal exit
+// in scheduleReconnect's catch, which only fires if the retry loop itself
+// throws synchronously — connectWithRetry never resolves-as-failed otherwise.)
+async function connectWithRetry () {
+  let attempt = 0
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      await connectOnce()
+      return
+    } catch (e) {
+      attempt += 1
+      const delay = Math.min(RECONNECT_BASE_MS * attempt, RECONNECT_MAX_MS)
+      console.error(`Ingest RabbitMQ connect attempt ${attempt} failed (${e && e.message}); retrying in ${delay}ms`)
+      await sleep(delay)
+    }
+  }
+}
+
+async function start () {
+  if (!url) {
+    throw new Error('RABBITMQ_URL (or AMQP_URL) env var must be set when INGEST_CONSUMER_TYPE=rabbitmq')
+  }
+  await connectWithRetry()
 }
 
 module.exports = { start }

--- a/utils/process-handlers.js
+++ b/utils/process-handlers.js
@@ -26,12 +26,20 @@ function installProcessHandlers (label) {
   })
 
   process.on('unhandledRejection', (reason) => {
-    console.error('Unhandled promise rejection', {
+    // Exit (like uncaughtException above) instead of only logging. A silently-
+    // swallowed rejection previously left the process running in an undefined
+    // state — most damagingly, an initial RabbitMQ connect failure that left
+    // the consumer pod up but NOT consuming (queue stalled at 0 consumers, pod
+    // looked healthy). Exiting lets kubernetes restart the pod, which (with the
+    // consumer's reconnect-with-backoff) recovers cleanly. Process state after
+    // an unhandled rejection is undefined, so continuing is never safe.
+    console.error('Unhandled promise rejection (will exit)', {
       service: label,
       message: reason && reason.message,
       stack: reason && reason.stack,
       reason: typeof reason === 'object' ? undefined : reason
     })
+    process.exit(1)
   })
 }
 


### PR DESCRIPTION
## Problem
When RabbitMQ blips (e.g. a broker restart), an `ingest-service-tasks` consumer could be left **permanently not consuming** while the pod still looked healthy (Express listening, Mongo connected). The upload queue stalls with **0 consumers attached** and only recovers via a manual `kubectl rollout restart`. Observed live on rfcx-local 2026-06-09 (RabbitMQ restarted during an unrelated deploy → all 16 consumers stalled, queue stuck at ~2.3k msgs).

## Root cause
`services/consumer/rabbitmq.js start()` established the AMQP connection **once**. Only *later* connection/channel `close` events triggered recovery (via `process.exit(1)`). But the **initial** `amqplib.connect()` rejection (ECONNREFUSED during a broker restart) had no handler attached yet, so it bubbled up as an **unhandledRejection** — and `utils/process-handlers.js` logged that **without exiting** (unlike `uncaughtException`, which does exit). Net: the process kept running and never retried the connection.

## Fix
- **`rabbitmq.js`**: `connectWithRetry()` wraps `connectOnce()` with capped linear backoff (`RABBITMQ_RECONNECT_BASE_MS`=2s … `RABBITMQ_RECONNECT_MAX_MS`=30s, env-overridable). Initial failures **retry** instead of throwing; a later connection/channel close schedules a fresh reconnect loop (guarded against double-fire) instead of `process.exit`-crash-looping the whole fleet. Half-open connections are closed on channel/queue-setup failure to avoid leaks.
- **`process-handlers.js`**: `unhandledRejection` now `exit(1)` like `uncaughtException` (process state is undefined after one) — last-resort safety net.
- **`main-tasks.js` / `main-all.js`**: guard `start()`/`main()` with `.catch(() => exit(1))` so a fatal start failure restarts the pod rather than stalling it.

## Testing
Behavioral test with a mock-amqplib harness (not committed): 2 initial ECONNREFUSED → retried → subscribed (no unhandled rejection); mid-stream `close` → reconnected + resubscribed. `node --check` + `eslint` clean on all 4 files.

No topology/behavior change to message handling (ack/nack/DLQ semantics unchanged). Backward compatible (the SQS/`amazon` consumer path is unaffected; only gains the safety-net guards).