### PR TITLE
ingest: ACK-drop terminal outcomes + preserve source on transient failure (rfcx-local)

### DIFF
--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -376,15 +376,27 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
       }
     }
 
-    // Cleanup is best-effort: a re-drive may have already deleted the
-    // source object (the DELETE fans out through s3-writer), or the local
-    // dir may not exist. A cleanup failure must NOT turn a handled-terminal
-    // outcome into a message nack -> DLQ, so guard it.
-    try {
-      await storage.deleteObject(uploadBucket, fileStoragePath)
-    } catch (e) {
-      console.info(`[${uploadId}] Cleanup: failed deleting source upload ${fileStoragePath}: ${e.message}`)
+    // Source-object cleanup: ONLY delete the original upload from the upload
+    // bucket on a handled-terminal outcome (duplicate / already-ingested /
+    // checksum / unsupported / size). On a TRANSIENT failure the message is
+    // nacked to the DLQ for retry/redrive, and the redrive re-reads this very
+    // object from the upload bucket -- deleting it here would make every retry
+    // fail with ENOENT and silently lose the recording. (Data-loss incident
+    // 2026-06-21: transient failures during a maintenance window deleted the
+    // source, stranding uploads whose DLQ retry could then never succeed.)
+    // Best-effort either way: a cleanup failure must NOT turn a handled-terminal
+    // outcome into a nack -> DLQ.
+    if (isHandledTerminal) {
+      try {
+        await storage.deleteObject(uploadBucket, fileStoragePath)
+      } catch (e) {
+        console.info(`[${uploadId}] Cleanup: failed deleting source upload ${fileStoragePath}: ${e.message}`)
+      }
+    } else {
+      console.info(`[${uploadId}] Cleanup: preserving source upload ${fileStoragePath} for DLQ redrive (transient failure)`)
     }
+    // Local scratch dir is always safe to remove (re-created from the upload
+    // object on redrive).
     try {
       await dirUtil.removeDirRecursively(streamLocalPath)
     } catch (e) {

--- a/services/rfcx/ingest.test.js
+++ b/services/rfcx/ingest.test.js
@@ -81,6 +81,12 @@ beforeEach(async () => {
 afterEach(async () => {
   process.env = originalEnv
   await rimraf(tempDirPath + '*', { glob: true })
+  // Restore all spies between tests. Otherwise per-test spies (e.g.
+  // jest.spyOn(segmentService,'createStreamFileData')) accumulate call counts
+  // across tests on top of the beforeEach spies, so assertions like
+  // expect(createSpy).not.toHaveBeenCalled() see leaked calls from earlier
+  // tests and fail depending on suite order (the CI flakiness root cause).
+  jest.restoreAllMocks()
 })
 afterAll(async () => {
   await stopDb()


### PR DESCRIPTION
## Why
Production (`rfcx-local-prod-2a07962` = `master`) is missing a stack of rfcx-local ingest fixes that accumulated locally but were never merged/deployed. Today's data-loss incident (2026-06-21) traced directly to two of these gaps:

1. **No ACK-drop of handled-terminal outcomes** → duplicates / already-ingested / checksum rejects were dead-lettered to the DLQ instead of ACK-dropped, inflating the DLQ with non-retryable messages.
2. **Source object deleted on transient failure** → the failure handler deleted the original upload from the upload bucket *unconditionally*. A transient failure nacks to the DLQ for retry, and the redrive re-reads that same object — so deleting it made every retry fail with ENOENT and **silently lose the recording**. During the incident this stranded ~94 uploads (most recovered from already-written segments; 2 unrecoverable → device re-upload requested).

## What (commits, in order)
- `09c6253` pre-transcode checksum dedup (skip already-ingested before transcode)
- `e19a89a` mongo connection-pool + server-selection-timeout
- `20d81ff` **ACK-drop handled-terminal outcomes** instead of dead-lettering
- `91b4b32` fix duplicate-nack regression in pre-transcode dedup path
- `63f80cd` use shared `@rfcx/s3-storage-client` in buildS3Client
- `ce27377` RabbitMQ consumer auto-reconnect + exit on unhandledRejection
- `2f8fa39` **preserve source object on transient failure** (this incident's root-cause fix)

## The headline fix (`2f8fa39`)
Guard the source-object delete behind `isHandledTerminal` so the original upload is only removed for non-retryable terminal outcomes. Transient failures now **preserve** the source so the DLQ redrive can succeed. Local scratch-dir removal stays unconditional (re-created from the upload object on redrive). No behavior change for handled-terminal outcomes.

## Testing
- `eslint` clean on changed file.
- `jest services/rfcx/ingest.test.js`: same 3 pass / 4 fail as the pristine baseline (the 4 failures are a local ffmpeg-env issue, unrelated). Test output confirms the new `Cleanup: preserving source upload ... for DLQ redrive (transient failure)` path executes on transient-failure cases.

## Deploy impact
Merging to `master` triggers the rfcx-local CD, which builds + rolls `ingest-service-api` and `ingest-service-tasks`. This deploys all 7 commits above to the live ingest pipeline.

Incident write-up: rfcx-local `runbooks/incident-2026-06-21-rabbitmq-quorum-classic-dlq.md`.