### PR TITLE
feat(ingest): allow large FLAC uploads + 24h duration (env-tunable limits)

### DIFF
--- a/routes/uploads.int.test.js
+++ b/routes/uploads.int.test.js
@@ -121,7 +121,7 @@ describe('POST /uploads', () => {
     expect(response.statusCode).toBe(400)
     expect(response.body.message).toEqual(`Past date upload: ${requestBody.timestamp}`)
   })
-  test('returns validation error if duration is more than 1 hour', async () => {
+  test('returns validation error if duration is more than 24 hours', async () => {
     const requestBody = {
       filename: '0a1824085e3f-2021-06-08T19-26-40.flac',
       timestamp: '2021-06-08T19:26:40.000Z',
@@ -129,12 +129,12 @@ describe('POST /uploads', () => {
       checksum: 'acd44fdcc42e0dad141f35ae1aa029fd6b3f9eca',
       sampleRate: 64000,
       targetBitrate: 1,
-      duration: 3_601_001,
+      duration: (24 * 60 * 60 * 1000) + (60 * 1000) + 1001, // > 24h + 1min grace
       fileSize: 1_000_000
     }
     const response = await request(app).post('/uploads').send(requestBody)
     expect(response.statusCode).toBe(400)
-    expect(response.body.message).toEqual('Audio duration is more than 1 hour')
+    expect(response.body.message).toEqual('Audio duration is more than 24 hours')
   })
   test('returns validation error if duration is 0', async () => {
     const requestBody = {
@@ -151,7 +151,7 @@ describe('POST /uploads', () => {
     expect(response.statusCode).toBe(400)
     expect(response.body.message).toEqual('Validation errors: Parameter \'duration\' is smaller than the minimum 1.')
   })
-  test('returns validation error if fileSize as flac file more than 150MB', async () => {
+  test('returns validation error if fileSize as flac file more than 1GB', async () => {
     const requestBody = {
       filename: '0a1824085e3f-2021-06-08T19-26-40.flac',
       timestamp: '2021-06-08T19:26:40.000Z',
@@ -160,12 +160,13 @@ describe('POST /uploads', () => {
       sampleRate: 64000,
       targetBitrate: 1,
       duration: 3600000,
-      fileSize: 150_000_001
+      fileSize: 1_073_741_825
     }
     const response = await request(app).post('/uploads').send(requestBody)
     expect(response.statusCode).toBe(400)
-    expect(response.body.message).toEqual('This flac file size is exceeding our limit (150MB)')
+    expect(response.body.message).toEqual('This flac file size is exceeding our limit (1073.741824MB)')
   })
+
   test('returns validation error if fileSize as wav file more than 200MB', async () => {
     const requestBody = {
       filename: '0a1824085e3f-2021-06-08T19-26-40.wav',
@@ -382,7 +383,9 @@ describe('POST /uploads', () => {
       stream: '0a1824085e3f',
       checksum: 'acd44fdcc42e0dad141f35ae1aa029fd6b3f9eca',
       sampleRate: 64000,
-      targetBitrate: 1
+      targetBitrate: 1,
+      duration: 3600000,
+      fileSize: 500_000_000 // > old 150MB cap, < new 1GB FLAC cap
     }
     const response = await request(app).post('/uploads').send(requestBody)
     const upload = await UploadModel.findOne({ checksum: requestBody.checksum })

--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -10,6 +10,7 @@ const arbimonService = require('../services/rfcx/arbimon')
 const auth0Service = require('../services/auth0')
 const moment = require('moment-timezone')
 const { getSampleRateFromFilename } = require('../services/rfcx/guardian')
+const { maxDurationWithGraceSeconds, maxDurationHoursDisplay, flacLimitSize, wavLimitSize, otherLimitSize } = require('../utils/limits')
 
 function getProjectIdFromStream (stream) {
   if (!stream) { return null }
@@ -111,15 +112,14 @@ router.route('/').post((req, res) => {
         throw new ValidationError(`Past date upload: ${params.timestamp}`)
       }
 
-      // Cannot upload file that duration more than following (milliseconds)
-      const durationLimit = (1000 * 60 * 60 * 1) + 1000 // Add 1 second for a file with 1 hour
+      // Cannot upload file that duration more than the configured max (milliseconds)
+      const durationLimit = maxDurationWithGraceSeconds * 1000
       if (params.duration && params.duration > durationLimit) {
-        throw new ValidationError('Audio duration is more than 1 hour')
+        throw new ValidationError(`Audio duration is more than ${maxDurationHoursDisplay} hours`)
       }
 
-      // Cannot upload file that size more than following
-      const flacLimitSize = 150_000_000
-      const wavLimitSize = 200_000_000
+      // Cannot upload file that size more than the per-extension limit.
+      // FLAC may be large (already compressed); WAV/other stay tightly bounded.
       const fileExtension = params.filename.split('.').pop().toLowerCase()
       if (fileExtension === 'flac' && params.fileSize && params.fileSize > flacLimitSize) {
         throw new ValidationError(`This flac file size is exceeding our limit (${flacLimitSize / 1_000_000}MB)`)
@@ -127,9 +127,9 @@ router.route('/').post((req, res) => {
       if (fileExtension === 'wav' && params.fileSize && params.fileSize > wavLimitSize) {
         throw new ValidationError(`This wav file size is exceeding our limit (${wavLimitSize / 1_000_000}MB)`)
       }
-      // Other file extensions, limit size same as flac
-      if (!['flac', 'wav'].includes(fileExtension) && params.fileSize && params.fileSize > flacLimitSize) {
-        throw new ValidationError(`This file size is exceeding our limit (${flacLimitSize / 1_000_000}MB)`)
+      // Other file extensions (e.g. opus)
+      if (!['flac', 'wav'].includes(fileExtension) && params.fileSize && params.fileSize > otherLimitSize) {
+        throw new ValidationError(`This file size is exceeding our limit (${otherLimitSize / 1_000_000}MB)`)
       }
       return params
     })

--- a/services/audio.js
+++ b/services/audio.js
@@ -1,6 +1,7 @@
 const ffmpeg = require('fluent-ffmpeg')
 const sha1File = require('sha1-file')
 const path = require('path')
+const { splitTimeoutMs, convertTimeoutMs } = require('../utils/limits')
 
 /**
  * Probe an audio file to find its sample rate, duration and other meta data
@@ -67,7 +68,7 @@ function split (sourceFile, destinationPath, maxDuration) {
     const timeout = setTimeout(function () {
       command.kill()
       reject(Error('Timeout')) // TODO: move to errors
-    }, 120000)
+    }, splitTimeoutMs)
 
     command
       .on('error', function (err, stdout, stderr) {
@@ -118,7 +119,7 @@ function convert (sourceFile, destinationPath) {
     const timeout = setTimeout(function () {
       command.kill()
       reject(Error('Timeout')) // TODO: move to errors
-    }, 60000)
+    }, convertTimeoutMs)
 
     command
       .on('error', function (err, stdout, stderr) {

--- a/services/consumer/amazon.js
+++ b/services/consumer/amazon.js
@@ -5,8 +5,7 @@ const { parseUploadFromFileName } = require('./misc')
 const TimeTracker = require('../../utils/time-tracker')
 const db = require('../db/mongo')
 
-const flacLimitSize = 150_000_000
-const wavLimitSize = 200_000_000
+const { flacLimitSize, wavLimitSize } = require('../../utils/limits')
 
 const consumer = Consumer.create({
   queueUrl: process.env.SQS_INGEST_TRIGGER_QUEUE_URL,

--- a/services/consumer/rabbitmq.js
+++ b/services/consumer/rabbitmq.js
@@ -4,8 +4,7 @@ const { parseUploadFromFileName } = require('./misc')
 const TimeTracker = require('../../utils/time-tracker')
 const db = require('../db/mongo')
 
-const flacLimitSize = 150_000_000
-const wavLimitSize = 200_000_000
+const { flacLimitSize, wavLimitSize } = require('../../utils/limits')
 
 const queueName = process.env.RABBITMQ_INGEST_TRIGGER_QUEUE || 'ingest-service-upload-production'
 const url = process.env.RABBITMQ_URL || process.env.AMQP_URL

--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -20,6 +20,7 @@ const losslessExtensions = ['.wav', '.flac']
 const extensionsRequiringConvToWav = ['.flac']
 
 const { IngestionError } = require('../../utils/errors')
+const { maxDurationWithGraceSeconds, maxDurationHoursDisplay } = require('../../utils/limits')
 const loggerIgnoredErrors = [
   /Duplicate file\. Matching sha1 signature already ingested\./,
   /This file was already ingested\./,
@@ -85,8 +86,8 @@ function validateAudioMeta (upload, meta, extension) {
   if (isNaN(meta.duration) || meta.duration === 0) {
     throw new IngestionError('Audio duration is zero')
   }
-  if (meta.duration > (60 * 60 * 1) + 1) { // Plus 1 second in case there is extra second in 1 hour file
-    throw new IngestionError('Audio duration is more than 1 hour')
+  if (meta.duration > maxDurationWithGraceSeconds) {
+    throw new IngestionError(`Audio duration is more than ${maxDurationHoursDisplay} hours`)
   }
   if (isNaN(meta.sampleCount) || meta.sampleCount === 0) {
     throw new IngestionError('Audio sampleCount is zero')

--- a/utils/limits.js
+++ b/utils/limits.js
@@ -1,0 +1,68 @@
+/**
+ * Centralised ingestion limits + ffmpeg timeouts.
+ *
+ * All values are env-overridable so they can be tuned (per environment) without
+ * a code change/rebuild. The defaults below are the production rfcx-local
+ * defaults.
+ *
+ * Size caps are enforced per file extension (see routes/uploads.js and the
+ * consumer modules). FLAC is allowed to be large because it is already
+ * compressed; WAV (uncompressed) and other formats stay tightly bounded so a
+ * single file can never blow up the worker's scratch space.
+ */
+
+function intFromEnv (name, fallback) {
+  const raw = process.env[name]
+  if (raw === undefined || raw === null || raw === '') { return fallback }
+  const n = parseInt(raw, 10)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
+// ---- Upload size caps (bytes) ----------------------------------------------
+// FLAC may be large (already compressed). Default 1 GiB.
+const flacLimitSize = intFromEnv('MAX_FLAC_BYTES', 1_073_741_824)
+// WAV stays bounded (uncompressed -> expensive to process). Default 200 MB.
+const wavLimitSize = intFromEnv('MAX_WAV_BYTES', 200_000_000)
+// Anything else (e.g. opus) uses the same bound as WAV's old default. 150 MB.
+const otherLimitSize = intFromEnv('MAX_OTHER_BYTES', 150_000_000)
+
+// ---- Duration cap (seconds) ------------------------------------------------
+// Max accepted audio duration (the clean cap, used for display). Default 24h.
+const maxDurationSeconds = intFromEnv('MAX_DURATION_SECONDS', 24 * 60 * 60)
+// Extra grace added on top of the cap before rejecting (absorbs rounding in
+// reported durations). Default 60s.
+const durationGraceSeconds = intFromEnv('MAX_DURATION_GRACE_SECONDS', 60)
+// Whole limit incl. grace (used for the actual comparison).
+const maxDurationWithGraceSeconds = maxDurationSeconds + durationGraceSeconds
+// Clean hours value for user-facing messages.
+const maxDurationHoursDisplay = maxDurationSeconds / 3600
+
+// ---- ffmpeg timeouts (milliseconds) ----------------------------------------
+// Whole-file convert (e.g. FLAC -> WAV, and per-segment WAV -> FLAC). A 24h
+// FLAC decode is the slowest step. Default 30 min.
+const convertTimeoutMs = intFromEnv('FFMPEG_CONVERT_TIMEOUT_MS', 30 * 60 * 1000)
+// Segment split (stream-copy, fast even for long files). Default 15 min.
+const splitTimeoutMs = intFromEnv('FFMPEG_SPLIT_TIMEOUT_MS', 15 * 60 * 1000)
+
+/**
+ * Returns the size cap (bytes) for a given file extension (no leading dot,
+ * lower-cased), e.g. sizeLimitForExtension('flac').
+ */
+function sizeLimitForExtension (fileExtension) {
+  if (fileExtension === 'flac') { return flacLimitSize }
+  if (fileExtension === 'wav') { return wavLimitSize }
+  return otherLimitSize
+}
+
+module.exports = {
+  flacLimitSize,
+  wavLimitSize,
+  otherLimitSize,
+  maxDurationSeconds,
+  durationGraceSeconds,
+  maxDurationWithGraceSeconds,
+  maxDurationHoursDisplay,
+  convertTimeoutMs,
+  splitTimeoutMs,
+  sizeLimitForExtension
+}


### PR DESCRIPTION
## What
Raises ingestion limits to accept **large FLAC files** and **long recordings**, while keeping the common ingestion path and resource footprint safe. All limits + ffmpeg timeouts are centralised in a new \`utils/limits.js\` and **env-overridable** (no rebuild needed to tune later).

## Changes
| Limit | Before | After | Env var |
|---|---|---|---|
| FLAC size cap | 150 MB | **1 GB** | \`MAX_FLAC_BYTES\` |
| WAV size cap | 200 MB | 200 MB (unchanged) | \`MAX_WAV_BYTES\` |
| Other (opus) cap | 150 MB | 150 MB (unchanged) | \`MAX_OTHER_BYTES\` |
| Max duration | 1 h | **24 h** (+1 min grace) | \`MAX_DURATION_SECONDS\` / \`MAX_DURATION_GRACE_SECONDS\` |
| ffmpeg split timeout | 120 s | **15 min** | \`FFMPEG_SPLIT_TIMEOUT_MS\` |
| ffmpeg convert timeout | 60 s | **30 min** | \`FFMPEG_CONVERT_TIMEOUT_MS\` |

## Why FLAC-only for large files
The size cap is enforced **per file extension**. By raising **only** the FLAC cap (and leaving WAV at 200 MB), a large upload can only enter the pipeline if it is already FLAC (compressed). This bounds the worst-case worker scratch usage: a 1 GB FLAC decodes to a few GB of WAV during \`FLAC→WAV→split→FLAC\`, whereas an uncompressed 1 GB WAV is never accepted. Duration (24 h) is the backstop on total sample count.

The duplicated hardcoded limits in \`routes/uploads.js\` and both consumers (\`rabbitmq\`, \`amazon\`) now read from the shared module.

## Out of scope (handled in rfcx-local deployment manifests, not here)
- Worker **scratch volume**: today \`/tmp/ingest-service\` is a **RAM-backed tmpfs (2Gi)**. To process multi-GB intermediates it must become a **disk-backed emptyDir** (nodes have ~18 GB ephemeral) with a larger \`sizeLimit\`, plus an ephemeral-storage request for graceful eviction. This is a manifest change applied separately to rfcx-local.

## Testing
- \`yarn lint\` clean across the repo.
- \`routes/uploads.int.test.js\`: 41/41 pass (updated duration + FLAC-cap assertions, added a 500 MB FLAC happy-path).
- The 6 \`services/audio|ingest\` failures seen locally are **pre-existing** (local ffmpeg Lavf62 vs container Lavf58) and fail identically on \`master\` without this change; they pass in CI's containerised \`docker compose run app yarn test\`.

## Deploy
Merging to \`master\` triggers the \`CD\` workflow → \`deploy-rfcx-local\` (namespace=production) → rebuilds \`build/Dockerfile\` and rolls out \`ingest-service-api\` + \`ingest-service-tasks\`.