### PR TITLE
fix(ingest): treat Core 5xx as transient (preserve source + DLQ), not terminal FAILED

### DIFF
--- a/services/rfcx/segments.js
+++ b/services/rfcx/segments.js
@@ -118,7 +118,22 @@ async function createStreamFileData (stream, payload) {
       }
     })
     .catch((err) => {
-      if (err.response && err.response.data && err.response.data.message) {
+      // Only map a Core response to a TERMINAL IngestionError when it is a
+      // genuinely non-retryable client error (HTTP 4xx). Core signals the
+      // terminal cases as ValidationError (400) / ForbiddenError (403):
+      // duplicate, already-ingested, same-timestamp. A 5xx (or any error with
+      // no response, e.g. a network blip) is TRANSIENT and MUST be re-thrown
+      // raw so ingest.js classifies it as non-terminal -> preserve the source
+      // upload + nack to the DLQ for redrive. Previously this switch keyed
+      // ONLY on the response message with `default: FAILED`, so a Core 500
+      // (body message 'Failed creating stream source file and segments')
+      // became IngestionError(FAILED) -> handled-terminal -> the consumer
+      // ack-dropped the message AND deleted the R2 source = silent data loss.
+      // That destroyed 115 originals during the 2026-06-30 MariaDB-failover
+      // sql_mode incident (core-api 500 on every legacy recordings INSERT).
+      const statusCode = err.response && err.response.status
+      const isClientError = typeof statusCode === 'number' && statusCode >= 400 && statusCode < 500
+      if (isClientError && err.response.data && err.response.data.message) {
         const message = err.response.data.message
         let status
         switch (message) {
@@ -131,10 +146,14 @@ async function createStreamFileData (stream, payload) {
             status = INGESTED
             break
           default:
+            // An unrecognized 4xx is still a non-retryable client error;
+            // record it terminally rather than redriving forever.
             status = FAILED
         }
         throw new IngestionError(message, status)
       } else {
+        // 5xx / no-response / unknown => transient. Re-throw raw so ingest.js
+        // preserves the source upload and nacks the message to the DLQ.
         throw err
       }
     })

--- a/services/rfcx/segments.test.js
+++ b/services/rfcx/segments.test.js
@@ -1,0 +1,91 @@
+/* eslint-disable no-unused-vars */
+const axios = require('../../utils/axios')
+const segmentService = require('./segments')
+const auth0Service = require('../auth0')
+const { status } = require('../../services/db/mongo')
+const { IngestionError } = require('../../utils/errors')
+
+// createStreamFileData() maps a Core-API error response to either:
+//   - a TERMINAL IngestionError (4xx: duplicate / already-ingested / etc.)
+//     -> ingest.js ACK-drops + deletes the source upload, OR
+//   - a re-thrown raw/transient error (5xx / no response)
+//     -> ingest.js PRESERVES the source upload + nacks to the DLQ for redrive.
+//
+// Regression guard for the 2026-06-30 data-loss incident: a Core 500 (body
+// message "Failed creating stream source file and segments") was being mapped
+// to IngestionError(FAILED) = handled-terminal = ack-drop + DELETE source,
+// silently destroying 115 originals. A 5xx MUST be treated as transient.
+
+const STREAM = 'abcdef123456'
+const PAYLOAD = { streamSourceFile: {}, streamSegments: [] }
+
+beforeAll(() => {
+  jest.spyOn(auth0Service, 'getToken').mockResolvedValue({ access_token: 'test-token' })
+})
+afterEach(() => {
+  jest.restoreAllMocks()
+  jest.spyOn(auth0Service, 'getToken').mockResolvedValue({ access_token: 'test-token' })
+})
+
+function axiosError (httpStatus, message) {
+  const err = new Error(`Request failed with status code ${httpStatus}`)
+  err.response = { status: httpStatus, data: message === undefined ? {} : { message } }
+  return err
+}
+
+describe('createStreamFileData error classification', () => {
+  test('Core 500 -> transient: re-throws raw (NOT IngestionError) so source is preserved + DLQ', async () => {
+    jest.spyOn(axios, 'post').mockRejectedValue(
+      axiosError(500, 'Failed creating stream source file and segments')
+    )
+    await expect(segmentService.createStreamFileData(STREAM, PAYLOAD)).rejects.toThrow()
+    let thrown
+    try { await segmentService.createStreamFileData(STREAM, PAYLOAD) } catch (e) { thrown = e }
+    expect(thrown).toBeDefined()
+    expect(thrown).not.toBeInstanceOf(IngestionError)
+  })
+
+  test('Core 503 -> transient: re-throws raw (NOT IngestionError)', async () => {
+    jest.spyOn(axios, 'post').mockRejectedValue(axiosError(503, 'Service Unavailable'))
+    let thrown
+    try { await segmentService.createStreamFileData(STREAM, PAYLOAD) } catch (e) { thrown = e }
+    expect(thrown).not.toBeInstanceOf(IngestionError)
+  })
+
+  test('No response (network error) -> transient: re-throws raw', async () => {
+    const netErr = new Error('ECONNRESET')
+    jest.spyOn(axios, 'post').mockRejectedValue(netErr)
+    let thrown
+    try { await segmentService.createStreamFileData(STREAM, PAYLOAD) } catch (e) { thrown = e }
+    expect(thrown).not.toBeInstanceOf(IngestionError)
+    expect(thrown).toBe(netErr)
+  })
+
+  test('Core 400 duplicate -> terminal IngestionError(DUPLICATE)', async () => {
+    jest.spyOn(axios, 'post').mockRejectedValue(
+      axiosError(400, 'Duplicate file. Matching sha1 signature already ingested.')
+    )
+    let thrown
+    try { await segmentService.createStreamFileData(STREAM, PAYLOAD) } catch (e) { thrown = e }
+    expect(thrown).toBeInstanceOf(IngestionError)
+    expect(thrown.status).toBe(status.DUPLICATE)
+  })
+
+  test('Core 400 already-ingested -> terminal IngestionError(INGESTED)', async () => {
+    jest.spyOn(axios, 'post').mockRejectedValue(
+      axiosError(400, 'This file was already ingested.')
+    )
+    let thrown
+    try { await segmentService.createStreamFileData(STREAM, PAYLOAD) } catch (e) { thrown = e }
+    expect(thrown).toBeInstanceOf(IngestionError)
+    expect(thrown.status).toBe(status.INGESTED)
+  })
+
+  test('Unrecognized 4xx -> terminal IngestionError(FAILED) (non-retryable client error)', async () => {
+    jest.spyOn(axios, 'post').mockRejectedValue(axiosError(403, 'Some other client error'))
+    let thrown
+    try { await segmentService.createStreamFileData(STREAM, PAYLOAD) } catch (e) { thrown = e }
+    expect(thrown).toBeInstanceOf(IngestionError)
+    expect(thrown.status).toBe(status.FAILED)
+  })
+})


### PR DESCRIPTION
## Problem (data loss)
`createStreamFileData()` (`services/rfcx/segments.js`) mapped a Core-API error to a status by matching **only** `err.response.data.message`, with `default: FAILED` — **ignoring the HTTP status code**. So a Core **500** (body message `Failed creating stream source file and segments`) became `IngestionError(message, FAILED)`.

In `ingest.js`, `FAILED` is a **handled-terminal** status → the consumer **ACK-drops the message AND deletes the source upload** from the upload bucket. Result: a transient/retryable Core 5xx → **silent data loss**, no DLQ entry, no redrive path.

This is the same data-loss class the code already guards against for the 2026-06-21 incident (transient failure must not delete the source), reached through a different door — and it bit in production on **2026-06-30**: a MariaDB HA failover exposed a missing `sql_mode` on the HA peer, so the legacy `recordings` INSERT 500'd on every upload, and **~115 originals** (one AudioMoth backfill, one stream) were destroyed because each Core 500 was misclassified as terminal. (The DB config gap is fixed separately; this PR fixes the consumer so a Core 5xx is recoverable, not lossy.)

## Fix
Only classify as a **terminal** `IngestionError` when Core returns a **4xx** — the genuinely non-retryable cases (duplicate / already-ingested / same-timestamp are `ValidationError`=400 / `ForbiddenError`=403). **5xx, no-response (network), and any unknown error are re-thrown raw**, so `ingest.js` treats them as transient → **preserve the source upload + nack to the DLQ** for redrive.

Behavior preserved for the legitimate terminal cases (duplicate/already-ingested still ACK-drop). Only the misclassified 5xx/transient path changes.

## Tests
New `services/rfcx/segments.test.js`:
- Core 500 / 503 / network-error → re-throws raw (NOT `IngestionError`) ✅ (regression guard for the incident)
- Core 400 duplicate → `IngestionError(DUPLICATE)`; already-ingested → `IngestionError(INGESTED)`; unknown 4xx → `IngestionError(FAILED)` ✅

`eslint` clean. (The pre-existing `ingest.test.js` ffmpeg-capability failures are environmental — fluent-ffmpeg `getAvailableFormats` — and unrelated to this change; identical with/without the patch.)