### PR TITLE
Preserve ingest upload sources for R2 lifecycle expiry

### DIFF
--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -236,8 +236,8 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
     // (fileData.checksum) is known here, before the expensive transcode +
     // 60-segment upload. If Core already has a stream source file with this
     // sha1 at this timestamp, the file was already ingested -> skip straight
-    // to the duplicate outcome (the catch block marks status + deletes the
-    // R2 source + acks). This is a perf optimization only; the authoritative
+    // to the duplicate outcome (the catch block marks status, preserves the
+    // R2 source for lifecycle expiry, and acks). This is a perf optimization only; the authoritative
     // dedup remains the post-transcode createStreamFileData call below, which
     // also guards the concurrent-worker race (two workers may both pass this
     // pre-check before either has created the source file).
@@ -304,10 +304,12 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
       pushHistogramMetric(fileExtension.substr(1), processingValue)
       tracker.logAndSetNewPoint(`[${uploadId}] pushed histogram metric`)
     }
-    console.info(`[${uploadId}] Cleaning up files`)
-    await storage.deleteObject(uploadBucket, fileStoragePath)
+    console.info(`[${uploadId}] Cleaning up local files`)
+    // Do not explicitly delete the original upload object from uploadBucket.
+    // It remains available for duplicate/stale deliveries and operator DLQ
+    // redrive, and is reaped by the Cloudflare R2 lifecycle rule instead.
     await dirUtil.removeDirRecursively(streamLocalPath)
-    tracker.logAndSetNewPoint(`[${uploadId}] cleaned up files`)
+    tracker.logAndSetNewPoint(`[${uploadId}] cleaned up local files`)
     tracker = null
     return { outcome: 'ingested', uploadId }
   } catch (err) {
@@ -376,27 +378,15 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
       }
     }
 
-    // Source-object cleanup: ONLY delete the original upload from the upload
-    // bucket on a handled-terminal outcome (duplicate / already-ingested /
-    // checksum / unsupported / size). On a TRANSIENT failure the message is
-    // nacked to the DLQ for retry/redrive, and the redrive re-reads this very
-    // object from the upload bucket -- deleting it here would make every retry
-    // fail with ENOENT and silently lose the recording. (Data-loss incident
-    // 2026-06-21: transient failures during a maintenance window deleted the
-    // source, stranding uploads whose DLQ retry could then never succeed.)
-    // Best-effort either way: a cleanup failure must NOT turn a handled-terminal
-    // outcome into a nack -> DLQ.
-    if (isHandledTerminal) {
-      try {
-        await storage.deleteObject(uploadBucket, fileStoragePath)
-      } catch (e) {
-        console.info(`[${uploadId}] Cleanup: failed deleting source upload ${fileStoragePath}: ${e.message}`)
-      }
-    } else {
-      console.info(`[${uploadId}] Cleanup: preserving source upload ${fileStoragePath} for DLQ redrive (transient failure)`)
-    }
+    // Do not explicitly delete the original upload from uploadBucket on either
+    // handled-terminal or transient outcomes. The upload object is intentionally
+    // kept for duplicate/stale deliveries and operator DLQ redrive, then reaped
+    // by the Cloudflare R2 lifecycle rule. This avoids races where a successful
+    // or terminal delivery deletes the source before a later duplicate/stale
+    // message can be ACK-dropped cleanly.
+    console.info(`[${uploadId}] Cleanup: preserving source upload ${fileStoragePath} for lifecycle expiry`)
     // Local scratch dir is always safe to remove (re-created from the upload
-    // object on redrive).
+    // object on redrive if needed).
     try {
       await dirUtil.removeDirRecursively(streamLocalPath)
     } catch (e) {

--- a/services/rfcx/ingest.test.js
+++ b/services/rfcx/ingest.test.js
@@ -4,6 +4,7 @@ const path = require('path')
 const fs = require('fs')
 const platform = process.env.PLATFORM || 'amazon'
 const storage = require(`../storage/${platform}`)
+const audioService = require('../audio')
 const segmentService = require('../rfcx/segments')
 const { status } = require('../../services/db/mongo')
 const { rimraf } = require('rimraf')
@@ -36,6 +37,25 @@ beforeEach(async () => {
   jest.spyOn(storage, 'deleteObject').mockReturnValue('')
   jest.spyOn(storage, 'copy').mockReturnValue('')
   jest.spyOn(storage, 'createFromData').mockReturnValue('')
+  jest.spyOn(audioService, 'convert').mockResolvedValue({
+    meta: {
+      duration: 299.806032,
+      sampleCount: 13221446,
+      sampleRate: 48000,
+      bitRate: 1,
+      codec: 'pcm_s16le',
+      size: 6672949,
+      checksum: UPLOAD.checksum
+    }
+  })
+  jest.spyOn(audioService, 'split').mockResolvedValue([0, 1, 2, 3, 4].map((idx) => ({
+    path: `${tempDirPath}segment-${idx}.wav`,
+    meta: {
+      duration: 60,
+      sampleCount: 2880000,
+      size: 1024 + idx
+    }
+  })))
   jest.spyOn(segmentService, 'createStreamFileData').mockReturnValue({
     streamSourceFile: {
       id: 'e52edb98-e482-41e3-b9fb-95de76d1f7e2',
@@ -108,6 +128,7 @@ describe('Test ingest service', () => {
 
     const newUpload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
     expect(newUpload.status).toBe(status.INGESTED)
+    expect(storage.deleteObject).not.toHaveBeenCalled()
   })
 
   test('Checksum error', async () => {
@@ -184,9 +205,10 @@ describe('Test ingest service', () => {
     expect(result).toBeDefined()
     expect(result.outcome).toBe('handled-terminal')
     expect(result.status).toBe(status.DUPLICATE)
+    expect(storage.deleteObject).not.toHaveBeenCalled()
   })
 
-  test('Handled-terminal resolves even if trailing cleanup fails', async () => {
+  test('Handled-terminal preserves source upload for lifecycle expiry', async () => {
     const fileName = 'test-5mins-lv8.flac'
     const pathFile = path.join(__dirname, '../../test/', fileName)
     const tempFilePath = tempDirPath + fileName
@@ -194,11 +216,10 @@ describe('Test ingest service', () => {
     fs.copyFile(pathFile, tempFilePath, (err) => { console.info(err) })
     const upload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
     jest.spyOn(segmentService, 'createStreamFileData').mockRejectedValue(new IngestionError('Duplicate file. Matching sha1 signature already ingested.', status.DUPLICATE))
-    // Simulate the source object already deleted by a prior re-drive.
-    jest.spyOn(storage, 'deleteObject').mockRejectedValue(new Error('NoSuchKey'))
 
     const result = await ingestService.ingest(`${UPLOAD.streamId}/${fileName}`, tempFilePath, UPLOAD.streamId, upload.id)
     expect(result.outcome).toBe('handled-terminal')
+    expect(storage.deleteObject).not.toHaveBeenCalled()
   })
 
   test('Pre-transcode dedup ACK-drops (coreData empty => no rollback crash)', async () => {


### PR DESCRIPTION
## Summary
- stop deleting original upload-source objects from `UPLOAD_BUCKET` in ingest success cleanup
- also preserve upload-source objects on handled-terminal outcomes, leaving Cloudflare R2 lifecycle to reap them
- keep rollback deletion of derived processed segment files in `INGEST_BUCKET`
- add ingest-service regression coverage that source uploads are not deleted

## Context
Cloudflare R2 bucket `rfcx-ingest-production` now has lifecycle rule `expire-uploads-1d` (`maxAge=86400`) while preserving `Default Multipart Abort Rule` (`maxAge=345600`). This PR aligns app behavior with lifecycle-owned cleanup so duplicate/stale queue deliveries and DLQ redrive retain a short source-object window.

## Validation
- PASS: `./node_modules/.bin/eslint services/rfcx/ingest.js services/rfcx/ingest.test.js`
- PASS: `./node_modules/.bin/jest services/rfcx/ingest.test.js --runInBand`
- NOTE: full `npm test` is blocked locally by pre-existing host FFmpeg 8.1.1 baseline failures in `services/audio.test.js` (`Output format segment is not available`, pinned encoder string changed from `Lavf58.76.100` to `Lavf62.12.101`).

## Rollout note
Do not roll `ingest-service-tasks` while the primary ingest queue is actively backlogged unless intentionally accepting a maxUnavailable=0 rolling replacement during active ingestion.