### PR TITLE
Add upload source cleanup worker

### DIFF
--- a/main-upload-source-cleanup.js
+++ b/main-upload-source-cleanup.js
@@ -1,0 +1,20 @@
+require('dotenv').config()
+
+require('./utils/process-handlers').installProcessHandlers('ingest-service-upload-source-cleanup')
+
+console.info('Upload source cleanup: starting')
+require('./utils/mongo')
+const mongoose = require('mongoose')
+const { runUploadSourceCleanup } = require('./services/rfcx/upload-source-cleanup')
+
+runUploadSourceCleanup()
+  .then(async (counts) => {
+    console.info('Upload source cleanup: finished', JSON.stringify(counts))
+    await mongoose.disconnect()
+    process.exit(counts.error > 0 ? 1 : 0)
+  })
+  .catch(async (e) => {
+    console.error('Upload source cleanup: failed', e && e.stack ? e.stack : e)
+    await mongoose.disconnect().catch(() => {})
+    process.exit(1)
+  })

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node main-all.js",
     "start:api": "node main-api.js",
     "start:tasks": "node main-tasks.js",
+    "start:upload-source-cleanup": "node main-upload-source-cleanup.js",
     "db-start": ". ./bin/mongo/start.sh",
     "db-stop": "docker container stop ingest-service-mongo",
     "test": "eslint \"**/*.js\" && jest",

--- a/services/db/models/mongoose/upload.js
+++ b/services/db/models/mongoose/upload.js
@@ -14,7 +14,9 @@ const UploadSchema = new mongoose.Schema({
   failureMessage: String,
   sampleRate: Number,
   targetBitrate: Number,
-  checksum: String
+  checksum: String,
+  uploadSourceDeletedAt: Date,
+  uploadSourceCleanupMessage: String
 })
 
 const Upload = mongoose.model('StreamUpload', UploadSchema)

--- a/services/rfcx/upload-source-cleanup.js
+++ b/services/rfcx/upload-source-cleanup.js
@@ -1,0 +1,151 @@
+const moment = require('moment-timezone')
+const path = require('path')
+
+const UploadModel = require('../db/models/mongoose/upload').Upload
+const db = require('../db/mongo')
+const segmentService = require('./segments')
+const storage = require(`../storage/${process.env.PLATFORM || 'amazon'}`)
+
+function getUploadBucket () {
+  return process.env.UPLOAD_BUCKET
+}
+
+function parseBool (value, defaultValue) {
+  if (value === undefined || value === null || value === '') {
+    return defaultValue
+  }
+  return ['1', 'true', 'yes', 'on'].includes(String(value).toLowerCase())
+}
+
+function parseStatuses (value) {
+  return String(value || `${db.status.INGESTED},${db.status.DUPLICATE}`)
+    .split(',')
+    .map(v => parseInt(v.trim(), 10))
+    .filter(v => !Number.isNaN(v))
+}
+
+function uploadSourceKey (upload) {
+  const ext = path.extname(upload.originalFilename || '').replace(/^\./, '').toLowerCase()
+  if (!ext) {
+    return null
+  }
+  return `${upload.streamId}/${upload._id}.${ext}`
+}
+
+function isNotFoundError (err) {
+  return err && (err.statusCode === 404 || err.code === 'NotFound' || err.code === 'NoSuchKey')
+}
+
+function buildConfig (env = process.env) {
+  return {
+    dryRun: parseBool(env.UPLOAD_SOURCE_CLEANUP_DRY_RUN, true),
+    ageHours: parseInt(env.UPLOAD_SOURCE_CLEANUP_AGE_HOURS || '24', 10),
+    batchSize: parseInt(env.UPLOAD_SOURCE_CLEANUP_BATCH_SIZE || '100', 10),
+    statuses: parseStatuses(env.UPLOAD_SOURCE_CLEANUP_STATUSES),
+    coreVerify: parseBool(env.UPLOAD_SOURCE_CLEANUP_CORE_VERIFY, true)
+  }
+}
+
+async function findCandidates (config) {
+  const cutoff = moment.utc().subtract(config.ageHours, 'hours').toDate()
+  return UploadModel.find({
+    status: { $in: config.statuses },
+    updatedAt: { $lte: cutoff },
+    uploadSourceDeletedAt: { $exists: false },
+    streamId: { $ne: null },
+    checksum: { $ne: null },
+    originalFilename: { $ne: null }
+  })
+    .sort({ updatedAt: 1 })
+    .limit(config.batchSize)
+}
+
+async function coreConfirmsIngested (upload) {
+  const found = await segmentService.findIngestedDuplicate(
+    upload.streamId,
+    upload.checksum,
+    moment.tz(upload.timestamp, 'UTC')
+  )
+  return !!(found && found.id)
+}
+
+async function markDeleted (upload, message) {
+  await UploadModel.updateOne(
+    { _id: upload._id, uploadSourceDeletedAt: { $exists: false } },
+    { $set: { uploadSourceDeletedAt: new Date(), uploadSourceCleanupMessage: message } }
+  )
+}
+
+async function cleanupUpload (upload, config) {
+  const key = uploadSourceKey(upload)
+  if (!key) {
+    console.warn(`[upload-source-cleanup] skip upload=${upload._id} reason=missing-extension`)
+    return 'skippedMissingExtension'
+  }
+
+  if (config.coreVerify) {
+    const verified = await coreConfirmsIngested(upload)
+    if (!verified) {
+      console.warn(`[upload-source-cleanup] skip upload=${upload._id} key=${key} reason=core-not-confirmed`)
+      return 'skippedCoreUnconfirmed'
+    }
+  }
+
+  if (config.dryRun) {
+    console.info(`[upload-source-cleanup] dry-run delete bucket=${getUploadBucket()} key=${key} upload=${upload._id}`)
+    return 'dryRun'
+  }
+
+  try {
+    await storage.deleteObject(getUploadBucket(), key)
+    await markDeleted(upload, `deleted ${getUploadBucket()}/${key}`)
+    console.info(`[upload-source-cleanup] deleted bucket=${getUploadBucket()} key=${key} upload=${upload._id}`)
+    return 'deleted'
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      await markDeleted(upload, `already missing ${getUploadBucket()}/${key}`)
+      console.info(`[upload-source-cleanup] already-missing bucket=${getUploadBucket()} key=${key} upload=${upload._id}`)
+      return 'alreadyMissing'
+    }
+    console.error(`[upload-source-cleanup] error upload=${upload._id} key=${key} ${err && err.message}`)
+    return 'error'
+  }
+}
+
+async function runUploadSourceCleanup (config = buildConfig()) {
+  if (!getUploadBucket()) {
+    throw new Error('UPLOAD_BUCKET is required')
+  }
+  const candidates = await findCandidates(config)
+  const counts = {
+    scanned: candidates.length,
+    dryRun: 0,
+    deleted: 0,
+    alreadyMissing: 0,
+    skippedMissingExtension: 0,
+    skippedCoreUnconfirmed: 0,
+    error: 0
+  }
+
+  for (const upload of candidates) {
+    const result = await cleanupUpload(upload, config)
+    counts[result] = (counts[result] || 0) + 1
+  }
+
+  console.info('[upload-source-cleanup] summary', JSON.stringify({
+    dryRun: config.dryRun,
+    ageHours: config.ageHours,
+    batchSize: config.batchSize,
+    statuses: config.statuses,
+    coreVerify: config.coreVerify,
+    uploadBucket: getUploadBucket(),
+    counts
+  }))
+  return counts
+}
+
+module.exports = {
+  buildConfig,
+  uploadSourceKey,
+  runUploadSourceCleanup
+}

--- a/services/rfcx/upload-source-cleanup.test.js
+++ b/services/rfcx/upload-source-cleanup.test.js
@@ -1,0 +1,98 @@
+const mongoose = require('mongoose')
+const moment = require('moment-timezone')
+
+const { status } = require('../db/mongo')
+const UploadModel = require('../db/models/mongoose/upload').Upload
+const segmentService = require('./segments')
+const storage = require(`../storage/${process.env.PLATFORM || 'amazon'}`)
+const { buildConfig, runUploadSourceCleanup, uploadSourceKey } = require('./upload-source-cleanup')
+const { startDb, stopDb, truncateDbModels, muteConsole } = require('../../utils/testing')
+
+const oldEnv = process.env
+
+beforeAll(async () => {
+  muteConsole('info')
+  muteConsole('warn')
+  await startDb()
+})
+
+beforeEach(async () => {
+  process.env = { ...oldEnv, UPLOAD_BUCKET: 'rfcx-ingest-production' }
+  await truncateDbModels(UploadModel)
+  jest.spyOn(segmentService, 'findIngestedDuplicate').mockResolvedValue({ id: 'source-file-id' })
+  jest.spyOn(storage, 'deleteObject').mockResolvedValue({})
+})
+
+afterEach(() => {
+  process.env = oldEnv
+  jest.restoreAllMocks()
+})
+
+afterAll(async () => {
+  await stopDb()
+})
+
+function uploadDoc (overrides = {}) {
+  return new UploadModel({
+    _id: new mongoose.Types.ObjectId(),
+    streamId: 'stream123',
+    userId: 'user123',
+    status: status.INGESTED,
+    timestamp: moment.utc().subtract(2, 'days').toDate(),
+    updatedAt: moment.utc().subtract(25, 'hours').toDate(),
+    createdAt: moment.utc().subtract(2, 'days').toDate(),
+    originalFilename: 'REC001.WAV',
+    checksum: 'a'.repeat(40),
+    ...overrides
+  }).save()
+}
+
+describe('upload source cleanup', () => {
+  test('defaults to ingested and duplicate terminal statuses', () => {
+    expect(buildConfig({}).statuses).toEqual([status.INGESTED, status.DUPLICATE])
+  })
+
+  test('builds upload source key from stream, id, and original extension', async () => {
+    const upload = await uploadDoc()
+    expect(uploadSourceKey(upload)).toBe(`stream123/${upload._id}.wav`)
+  })
+
+  test('dry-run scans eligible ingested uploads without deleting or marking', async () => {
+    const upload = await uploadDoc()
+    const counts = await runUploadSourceCleanup({ dryRun: true, ageHours: 24, batchSize: 10, statuses: [status.INGESTED], coreVerify: true })
+
+    expect(counts.dryRun).toBe(1)
+    expect(segmentService.findIngestedDuplicate).toHaveBeenCalledWith('stream123', 'a'.repeat(40), expect.any(Object))
+    expect(storage.deleteObject).not.toHaveBeenCalled()
+    const after = await UploadModel.findById(upload._id)
+    expect(after.uploadSourceDeletedAt).toBeUndefined()
+  })
+
+  test('deletes and marks eligible ingested uploads when dry-run is disabled', async () => {
+    const upload = await uploadDoc()
+    const counts = await runUploadSourceCleanup({ dryRun: false, ageHours: 24, batchSize: 10, statuses: [status.INGESTED], coreVerify: true })
+
+    expect(counts.deleted).toBe(1)
+    expect(storage.deleteObject).toHaveBeenCalledWith('rfcx-ingest-production', `stream123/${upload._id}.wav`)
+    const after = await UploadModel.findById(upload._id)
+    expect(after.uploadSourceDeletedAt).toBeTruthy()
+  })
+
+  test('does not delete failed or recently updated uploads', async () => {
+    await uploadDoc({ status: status.FAILED })
+    await uploadDoc({ updatedAt: moment.utc().subtract(2, 'hours').toDate() })
+    const counts = await runUploadSourceCleanup({ dryRun: false, ageHours: 24, batchSize: 10, statuses: [status.INGESTED], coreVerify: true })
+
+    expect(counts.scanned).toBe(0)
+    expect(storage.deleteObject).not.toHaveBeenCalled()
+  })
+
+  test('skips when Core does not confirm the upload is ingested', async () => {
+    await uploadDoc()
+    segmentService.findIngestedDuplicate.mockResolvedValue(null)
+    const counts = await runUploadSourceCleanup({ dryRun: false, ageHours: 24, batchSize: 10, statuses: [status.INGESTED], coreVerify: true })
+
+    expect(counts.skippedCoreUnconfirmed).toBe(1)
+    expect(storage.deleteObject).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add a dry-run-by-default upload-source cleanup entrypoint
- select only terminal, safe upload statuses (`INGESTED`, `DUPLICATE`) older than the configured age window
- verify against Core before deleting the original upload source object
- mark uploads after deletion so the cleanup is idempotent

## Safety
- default mode is dry-run (`UPLOAD_SOURCE_CLEANUP_DRY_RUN` must be `false` to delete)
- default age is 24h
- `WAITING`, `UPLOADED`, `FAILED`, and `CHECKSUM` are not selected by default
- per-upload Core verification is on by default

## Test plan
- `./node_modules/.bin/eslint main-upload-source-cleanup.js services/rfcx/upload-source-cleanup.js services/rfcx/upload-source-cleanup.test.js services/db/models/mongoose/upload.js`
- `./node_modules/.bin/jest services/rfcx/upload-source-cleanup.test.js --runInBand`
