### PR TITLE
feat(upload): add Postgres upload target registry shadow mode

### DIFF
--- a/db/upload-target-registry-seed-current-r2.sql
+++ b/db/upload-target-registry-seed-current-r2.sql
@@ -1,0 +1,55 @@
+-- Seed the current rfcx-local R2 upload bucket as the sole enabled target.
+-- Requires db/upload-target-registry.sql to have been applied first.
+-- This stores only a secret reference, never raw credentials.
+
+INSERT INTO upload_targets (
+  id,
+  version,
+  provider,
+  bucket,
+  endpoint,
+  region,
+  force_path_style,
+  state,
+  priority,
+  capacity_weight,
+  secret_ref,
+  lifecycle_days
+) VALUES (
+  'legacy-env-upload-bucket',
+  1,
+  's3-compatible',
+  'rfcx-ingest-production',
+  'https://d9f6a131cbef20f6f073d4c1d7a99703.r2.cloudflarestorage.com',
+  'auto',
+  true,
+  'enabled',
+  100,
+  100,
+  'k8s:apps-prod/ingest-service-api-prod-env+ingest-service-api-local-creds:UPLOAD_S3_ACCESS_KEY_ID,UPLOAD_S3_SECRET_KEY',
+  1
+)
+ON CONFLICT (id) DO UPDATE SET
+  version = EXCLUDED.version,
+  provider = EXCLUDED.provider,
+  bucket = EXCLUDED.bucket,
+  endpoint = EXCLUDED.endpoint,
+  region = EXCLUDED.region,
+  force_path_style = EXCLUDED.force_path_style,
+  state = EXCLUDED.state,
+  priority = EXCLUDED.priority,
+  capacity_weight = EXCLUDED.capacity_weight,
+  secret_ref = EXCLUDED.secret_ref,
+  lifecycle_days = EXCLUDED.lifecycle_days,
+  updated_at = now();
+
+INSERT INTO upload_target_policy_versions (active, policy, created_by)
+VALUES (
+  true,
+  '{"mode":"single-target","targetId":"legacy-env-upload-bucket"}'::jsonb,
+  'ingest-service/db/upload-target-registry-seed-current-r2.sql'
+)
+ON CONFLICT (active) WHERE active DO UPDATE SET
+  policy = EXCLUDED.policy,
+  created_by = EXCLUDED.created_by,
+  created_at = now();

--- a/db/upload-target-registry.sql
+++ b/db/upload-target-registry.sql
@@ -1,0 +1,44 @@
+-- Upload target registry for ingest-service signed upload URLs.
+-- Apply to the RFCx Postgres/Timescale cluster database chosen for operational
+-- service config (initially expected: core/public). This is intentionally
+-- additive and idempotent.
+
+CREATE TABLE IF NOT EXISTS upload_targets (
+  id text PRIMARY KEY,
+  version integer NOT NULL DEFAULT 1,
+  provider text NOT NULL,
+  bucket text NOT NULL,
+  endpoint text,
+  region text,
+  force_path_style boolean,
+  state text NOT NULL CHECK (state IN ('enabled', 'draining', 'disabled')),
+  priority integer NOT NULL DEFAULT 100,
+  locale_tags text[] NOT NULL DEFAULT '{}',
+  capacity_weight integer NOT NULL DEFAULT 100,
+  secret_ref text NOT NULL,
+  lifecycle_days integer,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS upload_targets_state_priority_idx
+  ON upload_targets (state, priority, id);
+
+CREATE TABLE IF NOT EXISTS upload_target_policy_versions (
+  id bigserial PRIMARY KEY,
+  active boolean NOT NULL DEFAULT false,
+  policy jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by text
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS upload_target_policy_versions_one_active_idx
+  ON upload_target_policy_versions (active)
+  WHERE active;
+
+COMMENT ON TABLE upload_targets IS
+  'Canonical registry of signed-upload destination buckets for ingest-service. Store secret references only, never raw credentials.';
+COMMENT ON COLUMN upload_targets.secret_ref IS
+  'Reference to Kubernetes/Vault/ops secret material used by ingest-service; raw access keys do not belong in this table.';
+COMMENT ON TABLE upload_target_policy_versions IS
+  'Versioned upload target routing policies. Redis may cache/project these rows but Postgres is source of truth.';

--- a/docs/upload-target-registry-2026-07-06.md
+++ b/docs/upload-target-registry-2026-07-06.md
@@ -74,11 +74,15 @@ The uploader app can keep using `uploadId`, `url`, `path`, and `bucket` as befor
 
 If ingest has to archive an invalid source file, it copies from the recorded source bucket/key instead of blindly using `UPLOAD_BUCKET`.
 
-## Future Postgres registry
+## Postgres registry
 
 Postgres should be the source of truth. Redis can be a fast projection/cache, not the canonical store.
 
-Suggested initial tables:
+The initial DDL is checked in at:
+
+- `db/upload-target-registry.sql`
+
+Initial tables:
 
 ```sql
 create table upload_targets (
@@ -125,6 +129,25 @@ Possible keys:
 
 Projection should include an etag/version. API pods can cache in memory briefly and refresh on version changes.
 
+## Runtime modes
+
+`UPLOAD_TARGET_REGISTRY_MODE` controls lookup behavior:
+
+- unset / `env`: current behavior, always use env-backed `UPLOAD_BUCKET` target.
+- `shadow`: query Postgres registry and compare it to the env target, but still return the env target. Registry failures log and fall back to env.
+- `active`: return the Postgres-selected target. Do not enable until shadow mode has run cleanly with exactly one env-equivalent enabled target.
+
+Postgres connection envs are explicit and optional:
+
+- `UPLOAD_TARGET_REGISTRY_POSTGRES_HOSTNAME` (fallback `POSTGRES_HOSTNAME`)
+- `UPLOAD_TARGET_REGISTRY_POSTGRES_PORT` (fallback `POSTGRES_PORT`, default `5432`)
+- `UPLOAD_TARGET_REGISTRY_POSTGRES_DB` (fallback `POSTGRES_DB`, default `core`)
+- `UPLOAD_TARGET_REGISTRY_POSTGRES_USERNAME` (fallback `POSTGRES_USERNAME`)
+- `UPLOAD_TARGET_REGISTRY_POSTGRES_PASSWORD` (fallback `POSTGRES_PASSWORD`)
+- `UPLOAD_TARGET_REGISTRY_POSTGRES_SSL_ENABLED` (fallback `POSTGRES_SSL_ENABLED`)
+
+For rfcx-local LAN/admin access, the Patroni service is reachable at `192.168.2.85:15432`, but in-cluster pods should use `postgres.data.svc.cluster.local:5432`.
+
 ## Rollout gates
 
 ### Gate A, compatibility code only
@@ -143,10 +166,13 @@ Projection should include an etag/version. API pods can cache in memory briefly 
 
 ### Gate C, registry read path
 
-- Add Postgres tables and seed one target matching current `UPLOAD_BUCKET`.
-- Add registry loader behind a feature flag, for example `UPLOAD_TARGET_REGISTRY_MODE=shadow`.
+- Apply `db/upload-target-registry.sql` to the selected Postgres database.
+- Seed one enabled target matching current `UPLOAD_BUCKET`/`UPLOAD_S3_*` values, with `id='legacy-env-upload-bucket'`, `version=1`, `provider='s3-compatible'`, `bucket='rfcx-ingest-production'`, `region='auto'`, `force_path_style=true`, and a `secret_ref` pointing to the existing Kubernetes secret/env source, not raw credentials.
+- Configure registry Postgres connection envs on `ingest-service-api` only.
+- Set `UPLOAD_TARGET_REGISTRY_MODE=shadow` on `ingest-service-api`.
 - Shadow mode compares registry-selected target with env target but still returns env target.
-- Emit metrics/logs for mismatches and registry/cache failures.
+- Watch logs for `[upload-targets] registry shadow mismatch` or `registry lookup failed`.
+- Keep tasks in env mode unless/until they also need registry lookup. Tasks already read immutable `uploadSource` from Mongo.
 
 ### Gate D, registry active, single target
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mongoose-long": "0.8.0",
     "newrelic": "^11.9.0",
     "nuts-serve": "git+https://github.com/rassokhina-e/nuts.git",
+    "pg": "^8.12.0",
     "prom-client": "^15.0.0",
     "querystring": "^0.2.1",
     "rimraf": "^5.0.5",

--- a/services/uploads/upload-target-registry.js
+++ b/services/uploads/upload-target-registry.js
@@ -1,0 +1,86 @@
+const { Pool } = require('pg')
+
+let pool
+
+function parseBool (value) {
+  if (value === undefined || value === null || value === '') { return undefined }
+  return value === true || value === 'true'
+}
+
+function sslConfig () {
+  const raw = process.env.UPLOAD_TARGET_REGISTRY_POSTGRES_SSL_ENABLED ?? process.env.POSTGRES_SSL_ENABLED
+  if (raw === undefined || raw === null || raw === '') { return undefined }
+  return parseBool(raw) ? { rejectUnauthorized: false } : false
+}
+
+function registryDbConfig () {
+  return {
+    host: process.env.UPLOAD_TARGET_REGISTRY_POSTGRES_HOSTNAME || process.env.POSTGRES_HOSTNAME,
+    port: Number(process.env.UPLOAD_TARGET_REGISTRY_POSTGRES_PORT || process.env.POSTGRES_PORT || 5432),
+    database: process.env.UPLOAD_TARGET_REGISTRY_POSTGRES_DB || process.env.POSTGRES_DB || 'core',
+    user: process.env.UPLOAD_TARGET_REGISTRY_POSTGRES_USERNAME || process.env.POSTGRES_USERNAME,
+    password: process.env.UPLOAD_TARGET_REGISTRY_POSTGRES_PASSWORD || process.env.POSTGRES_PASSWORD,
+    ssl: sslConfig(),
+    max: Number(process.env.UPLOAD_TARGET_REGISTRY_POSTGRES_POOL_MAX || 2),
+    idleTimeoutMillis: Number(process.env.UPLOAD_TARGET_REGISTRY_POSTGRES_IDLE_TIMEOUT_MS || 30000),
+    connectionTimeoutMillis: Number(process.env.UPLOAD_TARGET_REGISTRY_POSTGRES_CONNECT_TIMEOUT_MS || 2000)
+  }
+}
+
+function getPool () {
+  if (!pool) {
+    pool = new Pool(registryDbConfig())
+  }
+  return pool
+}
+
+function rowToTarget (row) {
+  if (!row) { return null }
+  return {
+    id: row.id,
+    version: Number(row.version || 1),
+    provider: row.provider,
+    bucket: row.bucket,
+    endpoint: row.endpoint || undefined,
+    region: row.region || undefined,
+    forcePathStyle: row.force_path_style === null ? undefined : row.force_path_style
+  }
+}
+
+async function getEnabledUploadTargets () {
+  const result = await getPool().query(`
+    SELECT id, version, provider, bucket, endpoint, region, force_path_style, priority, capacity_weight
+    FROM upload_targets
+    WHERE state = 'enabled'
+    ORDER BY priority ASC, id ASC
+  `)
+  return result.rows.map(rowToTarget).filter(Boolean)
+}
+
+async function selectRegistryUploadTarget (_context = {}) {
+  const targets = await getEnabledUploadTargets()
+  if (targets.length === 0) {
+    throw new Error('No enabled upload targets found in registry')
+  }
+
+  // Phase 2 shadow/single-target implementation: deterministic first enabled
+  // target. Weighted/multi-target policy comes later, after the registry is
+  // proven in shadow mode with exactly the env-equivalent target.
+  return targets[0]
+}
+
+async function closeRegistryPool () {
+  if (pool) {
+    const closing = pool
+    pool = undefined
+    await closing.end()
+  }
+}
+
+module.exports = {
+  selectRegistryUploadTarget,
+  getEnabledUploadTargets,
+  closeRegistryPool,
+  registryDbConfig,
+  rowToTarget
+}

--- a/services/uploads/upload-targets.js
+++ b/services/uploads/upload-targets.js
@@ -1,6 +1,12 @@
+const registry = require('./upload-target-registry')
+
 function parseBool (value) {
   if (value === undefined || value === null || value === '') { return undefined }
   return value === true || value === 'true'
+}
+
+function registryMode () {
+  return (process.env.UPLOAD_TARGET_REGISTRY_MODE || 'env').toLowerCase()
 }
 
 function legacyUploadTarget () {
@@ -19,12 +25,45 @@ function legacyUploadTarget () {
   }
 }
 
-async function selectUploadTarget (_context = {}) {
-  // Phase 1 compatibility shim: all uploads still use the legacy env-backed
-  // target. A future implementation should replace this with a Postgres-backed
-  // registry lookup, optionally cached/projected in Redis, while preserving the
-  // returned target shape.
-  return legacyUploadTarget()
+function targetsEquivalent (a, b) {
+  return a && b &&
+    a.id === b.id &&
+    Number(a.version || 1) === Number(b.version || 1) &&
+    a.provider === b.provider &&
+    a.bucket === b.bucket &&
+    (a.endpoint || undefined) === (b.endpoint || undefined) &&
+    (a.region || undefined) === (b.region || undefined) &&
+    a.forcePathStyle === b.forcePathStyle
+}
+
+async function selectUploadTarget (context = {}) {
+  const mode = registryMode()
+  const legacy = legacyUploadTarget()
+
+  if (mode === 'env' || mode === 'off' || mode === 'disabled') {
+    return legacy
+  }
+
+  try {
+    const selected = await registry.selectRegistryUploadTarget(context)
+
+    if (mode === 'shadow') {
+      if (!targetsEquivalent(legacy, selected)) {
+        console.warn('[upload-targets] registry shadow mismatch', JSON.stringify({ legacy, selected }))
+      }
+      return legacy
+    }
+
+    if (mode === 'active') {
+      return selected
+    }
+
+    console.warn(`[upload-targets] unknown UPLOAD_TARGET_REGISTRY_MODE=${mode}; falling back to env target`)
+    return legacy
+  } catch (err) {
+    console.error('[upload-targets] registry lookup failed; falling back to env target', err && err.message)
+    return legacy
+  }
 }
 
 function sourceForKey (target, key) {
@@ -61,5 +100,7 @@ module.exports = {
   selectUploadTarget,
   sourceForKey,
   sourceFromUpload,
-  legacyUploadTarget
+  legacyUploadTarget,
+  registryMode,
+  targetsEquivalent
 }

--- a/services/uploads/upload-targets.test.js
+++ b/services/uploads/upload-targets.test.js
@@ -1,0 +1,94 @@
+const registryPath = './upload-target-registry'
+jest.mock(registryPath)
+const registry = require(registryPath)
+
+const originalEnv = process.env
+
+function reloadUploadTargets () {
+  jest.resetModules()
+  jest.doMock(registryPath, () => registry)
+  return require('./upload-targets')
+}
+
+describe('upload target selection', () => {
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      PLATFORM: 'amazon',
+      UPLOAD_BUCKET: 'rfcx-ingest-production',
+      UPLOAD_S3_ENDPOINT: 'https://example.r2.cloudflarestorage.com',
+      UPLOAD_S3_REGION_ID: 'auto',
+      UPLOAD_S3_FORCE_PATH_STYLE: 'true'
+    }
+    registry.selectRegistryUploadTarget.mockReset()
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  test('defaults to env-backed legacy target', async () => {
+    const uploadTargets = reloadUploadTargets()
+    const target = await uploadTargets.selectUploadTarget()
+
+    expect(target).toEqual(expect.objectContaining({
+      id: 'legacy-env-upload-bucket',
+      provider: 's3-compatible',
+      bucket: 'rfcx-ingest-production',
+      endpoint: 'https://example.r2.cloudflarestorage.com',
+      region: 'auto',
+      forcePathStyle: true
+    }))
+    expect(registry.selectRegistryUploadTarget).not.toHaveBeenCalled()
+  })
+
+  test('shadow mode queries registry but still returns env target', async () => {
+    process.env.UPLOAD_TARGET_REGISTRY_MODE = 'shadow'
+    registry.selectRegistryUploadTarget.mockResolvedValue({
+      id: 'db-target',
+      version: 1,
+      provider: 's3-compatible',
+      bucket: 'other-bucket',
+      endpoint: 'https://other.example',
+      region: 'auto',
+      forcePathStyle: true
+    })
+    const uploadTargets = reloadUploadTargets()
+    const target = await uploadTargets.selectUploadTarget({ streamId: 'stream-1' })
+
+    expect(registry.selectRegistryUploadTarget).toHaveBeenCalledWith({ streamId: 'stream-1' })
+    expect(target.id).toBe('legacy-env-upload-bucket')
+    expect(target.bucket).toBe('rfcx-ingest-production')
+  })
+
+  test('active mode returns registry-selected target', async () => {
+    process.env.UPLOAD_TARGET_REGISTRY_MODE = 'active'
+    registry.selectRegistryUploadTarget.mockResolvedValue({
+      id: 'db-target',
+      version: 2,
+      provider: 's3-compatible',
+      bucket: 'r2-locale-a',
+      endpoint: 'https://r2-a.example',
+      region: 'auto',
+      forcePathStyle: true
+    })
+    const uploadTargets = reloadUploadTargets()
+    const target = await uploadTargets.selectUploadTarget()
+
+    expect(target).toEqual(expect.objectContaining({
+      id: 'db-target',
+      version: 2,
+      bucket: 'r2-locale-a'
+    }))
+  })
+
+  test('registry errors fall back to env target', async () => {
+    process.env.UPLOAD_TARGET_REGISTRY_MODE = 'active'
+    registry.selectRegistryUploadTarget.mockRejectedValue(new Error('registry unavailable'))
+    const uploadTargets = reloadUploadTargets()
+    const target = await uploadTargets.selectUploadTarget()
+
+    expect(target.id).toBe('legacy-env-upload-bucket')
+    expect(target.bucket).toBe('rfcx-ingest-production')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5767,6 +5767,62 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
+pg-cloudflare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz#4b4c20e6d8ae531d400730f4804571a8d62f1497"
+  integrity sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==
+
+pg-connection-string@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.14.0.tgz#abc26ee4f37c56c0f3ae0fcf0b0653cc4e1c0fd9"
+  integrity sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.14.0.tgz#f35ae4eb846780cad71af24099b3edfa9781ad90"
+  integrity sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==
+
+pg-protocol@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.15.0.tgz#758f6c0679cc0bbf4938603b7597703f333180c0"
+  integrity sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==
+
+pg-types@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.12.0:
+  version "8.22.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.22.0.tgz#55ca3975026180c6dced6eec3a20a844c2dc9237"
+  integrity sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==
+  dependencies:
+    pg-connection-string "^2.14.0"
+    pg-pool "^3.14.0"
+    pg-protocol "^1.15.0"
+    pg-types "2.2.0"
+    pgpass "1.0.5"
+  optionalDependencies:
+    pg-cloudflare "^1.4.0"
+
+pgpass@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -5788,6 +5844,28 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz#c40b3da0222c500ff1e51c5d7014b60b79697c7a"
+  integrity sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -6725,6 +6803,11 @@ speedometer@~0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
   integrity sha512-phdEoDlA6EUIVtzwq1UiNMXDUogczp204aYF/yfOhjNePWFfIpBJ1k5wLMuXQhEOOMjuTJEcc4vdZa+vuP+n/Q==
+
+split2@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
## Summary

Adds the next, still-safe registry phase for ingest-service upload targets.

- Adds Postgres registry DDL:
  - `db/upload-target-registry.sql`
  - `upload_targets`
  - `upload_target_policy_versions`
- Adds current R2 target seed template:
  - `db/upload-target-registry-seed-current-r2.sql`
  - stores only a secret reference, not raw credentials
- Adds feature-flagged registry reader:
  - default `UPLOAD_TARGET_REGISTRY_MODE=env` preserves current behavior
  - `shadow` queries Postgres and compares with env target, but still returns env target
  - `active` can return registry target, but should not be enabled until shadow is proven clean
- Adds unit tests for env/shadow/active/fallback behavior.
- Updates rollout docs with connection envs and Gate C procedure.

## Safety

This PR does not apply live DDL and does not enable registry mode by itself.

Current behavior remains unchanged unless `UPLOAD_TARGET_REGISTRY_MODE` is explicitly set to `shadow` or `active`.

Recommended rollout after merge:

1. Apply `db/upload-target-registry.sql` to the selected Postgres DB, likely `core`.
2. Seed the env-equivalent R2 target using `db/upload-target-registry-seed-current-r2.sql`.
3. Configure registry Postgres connection envs on `ingest-service-api` only.
4. Enable `UPLOAD_TARGET_REGISTRY_MODE=shadow` on API only.
5. Watch for `[upload-targets] registry shadow mismatch` or `registry lookup failed`.
6. Do not enable `active` until shadow mode has run cleanly.

Live read-only check before this PR: registry tables were absent in `core` and `postgres`.

## Validation

- `npm run jest -- services/uploads/upload-targets.test.js --runInBand`
- `npm run jest -- routes/uploads.int.test.js --runInBand`
- `npm run lint`
- `git diff --check`
