### PR TITLE
fix(ingest): stream archive upload sources across providers

### DIFF
--- a/services/db/mongo.js
+++ b/services/db/mongo.js
@@ -89,6 +89,8 @@ function updateUploadStatus (uploadId, statusNumber, failureMessage = null) {
       upload.updatedAt = moment().tz('UTC').toDate()
       if (failureMessage != null) {
         upload.failureMessage = failureMessage
+      } else if ([status.UPLOADED, status.INGESTED].includes(statusNumber)) {
+        upload.failureMessage = undefined
       }
       return upload.save()
     })

--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -365,23 +365,25 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
       }
     }
 
-    // Optionally copy the failed upload + a .txt error log into a
-    // dedicated error bucket so ops can inspect failures. Disabled by
-    // default in v2 to avoid cross-provider server-side copy issues
-    // (the upload bucket may live on a different provider than the
-    // error bucket, in which case AWS-SDK CopyObject silently fails).
-    // Set ERROR_BUCKET_ENABLED=true to re-enable on environments
-    // where both buckets share a provider (e.g. AWS-prod legacy).
-    if (process.env.ERROR_BUCKET_ENABLED === 'true' && errorBucket && !loggerIgnoredErrors.includes(message)) {
+    // Optionally archive the failed upload + a .txt error log into a dedicated
+    // error bucket so ops can inspect failures. When the upload source has its
+    // own provider/endpoint (e.g. Cloudflare R2) we stream source -> destination
+    // instead of using S3 server-side CopyObject, because cross-provider copy is
+    // not portable.
+    const configuredErrorBucket = process.env.ERROR_BUCKET || errorBucket
+    if (process.env.ERROR_BUCKET_ENABLED === 'true' && configuredErrorBucket && !loggerIgnoredErrors.some((r) => r.test(message))) {
       try {
-        const sourceBucket = uploadSource?.bucket || uploadBucket
-        const sourceKey = uploadSource?.key || fileStoragePath
-        await storage.copy(`${sourceBucket}/${sourceKey}`, errorBucket, fileStoragePath)
+        if (uploadSource && uploadSource.bucket) {
+          await storage.copyFromSource(uploadSource, configuredErrorBucket, fileStoragePath)
+        } else {
+          const sourceBucket = uploadBucket
+          await storage.copy(`${sourceBucket}/${fileStoragePath}`, configuredErrorBucket, fileStoragePath)
+        }
         // create error log text file in the same bucket
         const storageErrorFilePath = fileStoragePath.replace(path.extname(fileStoragePath), '.txt')
-        await storage.createFromData(errorBucket, storageErrorFilePath, `message: ${err.message}\n\nstack: ${err.stack}`)
+        await storage.createFromData(configuredErrorBucket, storageErrorFilePath, `message: ${err.message}\n\nstack: ${err.stack}`)
       } catch (errOnErrorCopy) {
-        console.warn(`[${uploadId}] Failed to archive error blob to ${errorBucket}: ${errOnErrorCopy.message}`)
+        console.warn(`[${uploadId}] Failed to archive error blob to ${configuredErrorBucket}: ${errOnErrorCopy.message}`)
       }
     }
 

--- a/services/rfcx/ingest.test.js
+++ b/services/rfcx/ingest.test.js
@@ -36,6 +36,7 @@ beforeEach(async () => {
   jest.spyOn(storage, 'download').mockReturnValue('')
   jest.spyOn(storage, 'upload').mockReturnValue(Promise.resolve({ ETag: true }))
   jest.spyOn(storage, 'deleteObject').mockReturnValue('')
+  jest.spyOn(storage, 'copyFromSource').mockReturnValue(Promise.resolve({ ETag: true }))
   jest.spyOn(storage, 'copy').mockReturnValue('')
   jest.spyOn(storage, 'createFromData').mockReturnValue('')
   jest.spyOn(audioService, 'convert').mockResolvedValue({
@@ -124,11 +125,14 @@ describe('Test ingest service', () => {
       console.info(err)
     })
     const upload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+    upload.failureMessage = 'previous transient failure'
+    await upload.save()
 
     await ingestService.ingest(`${UPLOAD.streamId}/${fileName}`, tempFilePath, UPLOAD.streamId, upload.id)
 
     const newUpload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
     expect(newUpload.status).toBe(status.INGESTED)
+    expect(newUpload.failureMessage).toBeUndefined()
     expect(storage.download).toHaveBeenCalledWith(`${UPLOAD.streamId}/${fileName}`, path.join(tempDirPath, UPLOAD.streamId, fileName), expect.objectContaining({ bucket: 'streams-uploads', key: `${UPLOAD.streamId}/${fileName}` }))
     expect(storage.deleteObject).not.toHaveBeenCalled()
   })
@@ -191,6 +195,35 @@ describe('Test ingest service', () => {
     const newUpload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
     expect(newUpload.status).toBe(status.DUPLICATE)
     expect(newUpload.failureMessage).toBe('Duplicate file. Matching sha1 signature already ingested.')
+  })
+
+  test('Error archive streams from recorded upload source', async () => {
+    const fileName = 'test-1min-lv8.flac'
+    const pathFile = path.join(__dirname, '../../test/', fileName)
+    const tempFilePath = tempDirPath + fileName
+    process.env.CACHE_DIRECTORY = tempDirPath
+    process.env.ERROR_BUCKET_ENABLED = 'true'
+    process.env.ERROR_BUCKET = 'rfcx-streams-errors-production'
+    fs.copyFile(pathFile, tempFilePath, (err) => { console.info(err) })
+    const upload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+    upload.uploadSource = {
+      targetId: 'legacy-env-upload-bucket',
+      targetVersion: 1,
+      provider: 's3-compatible',
+      bucket: 'rfcx-ingest-production',
+      key: `${UPLOAD.streamId}/${fileName}`,
+      endpoint: 'https://example.r2.cloudflarestorage.com',
+      region: 'auto',
+      forcePathStyle: true
+    }
+    await upload.save()
+
+    const result = await ingestService.ingest(`${UPLOAD.streamId}/${fileName}`, tempFilePath, UPLOAD.streamId, upload.id)
+
+    expect(result.outcome).toBe('handled-terminal')
+    expect(result.status).toBe(status.CHECKSUM)
+    expect(storage.copyFromSource).toHaveBeenCalledWith(expect.objectContaining({ bucket: 'rfcx-ingest-production', key: `${UPLOAD.streamId}/${fileName}` }), 'rfcx-streams-errors-production', `${UPLOAD.streamId}/${fileName}`)
+    expect(storage.copy).not.toHaveBeenCalled()
   })
 
   test('Duplicate is ACK-dropped (ingest resolves with handled-terminal outcome)', async () => {

--- a/services/storage/amazon.js
+++ b/services/storage/amazon.js
@@ -156,6 +156,15 @@ function createFromData (Bucket, remotePath, data) {
   return clientFor(Bucket).putObject(opts).promise()
 }
 
+function copyFromSource (source, Bucket, Key, ContentType) {
+  const sourceBucket = source?.bucket || uploadBucket
+  const sourceKey = source?.key || Key
+  const sourceClient = uploadClientForSource(source)
+  const readStream = sourceClient.getObject({ Bucket: sourceBucket, Key: sourceKey }).createReadStream()
+  const opts = { Bucket, Key, Body: readStream, ContentType }
+  return clientFor(Bucket).upload(opts).promise()
+}
+
 /**
  * Copies a file on S3.
  *
@@ -185,6 +194,7 @@ module.exports = {
   download,
   upload,
   createFromData,
+  copyFromSource,
   copy,
   deleteObject
 }


### PR DESCRIPTION
## Summary

Follow-up to the upload-source/R2 rollout.

- Archives failed upload originals by streaming from the recorded `uploadSource` to the error bucket when a per-upload source is available.
- Keeps legacy server-side `copyObject` fallback for older uploads without `uploadSource`.
- Fixes ignored-error matching to use regex `.some(...)` instead of `includes(...)`, so handled duplicates do not attempt optional error archival.
- Clears stale `failureMessage` when an upload is successfully reprocessed to `UPLOADED` / `INGESTED`.

## Why

After PR #106 deployed, duplicate uploads processed correctly, but optional error archival could log:

```text
Failed to archive error blob to rfcx-streams-errors-production: source rfcx-ingest-production/... not found in cache or chain
```

Root cause: server-side CopyObject through the destination/error bucket provider cannot copy directly from the Cloudflare R2 upload source. Streaming source -> destination is the portable path.

During selective DLQ redrive, 25 uploads moved from `FAILED` to `INGESTED`, but retained their old generic `failureMessage`. Successful status transitions should clear stale failure text.

## Validation

- `npm run jest -- services/rfcx/ingest.test.js --runInBand`
- `npm run lint`
- `git diff --check`

## Operational note

Current production is healthy before this PR:

- `ingest-service-api`: 2/2 ready
- `ingest-service-tasks`: 18/18 ready
- primary upload queue: 0 ready / 0 unacked / 18 consumers
- DLQ: 1 intentional 0-byte holdback
- registry shadow logs: no lookup failures or mismatches
