### PR TITLE
feat(ingest): weighted multi-lane consumer + lane router + laneTier plumbing

### DIFF
--- a/main-tasks.js
+++ b/main-tasks.js
@@ -26,3 +26,15 @@ ingestConsumer.start().catch((e) => {
   console.error('Ingest consumer failed to start; exiting for restart', e && e.message)
   process.exit(1)
 })
+
+// Ingest lane ROUTER (rfcx-local, 2026-07-14): consume the legacy upload queue,
+// look up each upload's laneTier from Mongo, re-publish onto the matching lane
+// queue for the weighted multi-lane consumer above. Only meaningful for the
+// rabbitmq consumer type; disabled via INGEST_LANE_ROUTER=off. Self-healing;
+// does NOT exit the pod on failure (the consumer is the liveness anchor).
+if (consumerType === 'rabbitmq') {
+  const { startRouter } = require('./services/consumer/router')
+  startRouter().catch((e) => {
+    console.error('Ingest lane router failed (continuing; consumer still drains legacy):', e && e.message)
+  })
+}

--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -59,6 +59,11 @@ function uploadConverter (body) {
   converter.convert('sampleRate').optional().toInt()
   converter.convert('targetBitrate').optional().toInt()
   converter.convert('checksum').optional().toString()
+  // rfcx-local lane tier (2026-07-14): OPTIONAL requested ingest lane group.
+  // express|priority|standard; anything else (or absent) -> standard. The
+  // CRITERIA that decide the tier are applied here in the web-service (future);
+  // for now we accept a client/service-supplied hint and default to standard.
+  converter.convert('laneTier').optional().toString()
   return converter
 }
 
@@ -95,6 +100,18 @@ async function validateUploadParams (params) {
     throw new ValidationError(`This file size is exceeding our limit (${otherLimitSize / 1_000_000}MB)`)
   }
   return params
+}
+
+// rfcx-local lane-tier selection (2026-07-14). THE place to implement the
+// criteria (express if small file, priority if paid project/tier, etc.). For
+// now: honour an explicit `laneTier` on the request; otherwise standard.
+// Returns one of express|priority|standard.
+const LANE_TIERS = ['express', 'priority', 'standard']
+function deriveLaneTier (params, _ctx) {
+  const requested = (params && params.laneTier ? String(params.laneTier) : '').toLowerCase()
+  if (LANE_TIERS.includes(requested)) { return requested }
+  // --- future criteria go here (size/duration/project-tier) ---
+  return 'standard'
 }
 
 async function parseUploadParams (body) {
@@ -140,6 +157,10 @@ async function createSignedUpload (rawParams, { req, idToken, userId }) {
     fileExtension,
     timestamp: timestamp.toISOString()
   })
+  // rfcx-local lane tier: apply the (future) selection criteria here. For now,
+  // honour an explicit request and default to standard. This is the single
+  // place to add "express if small", "priority if paid project", etc.
+  const laneTier = deriveLaneTier(params, { uploadProject })
   const upload = await db.generateUpload({
     streamId: stream,
     userId,
@@ -151,7 +172,8 @@ async function createSignedUpload (rawParams, { req, idToken, userId }) {
     sampleRate,
     targetBitrate,
     checksum,
-    uploadTarget
+    uploadTarget,
+    laneTier
   })
   const uploadId = upload.id
   const url = await storage.getSignedUrl(upload.path, 'audio/' + fileExtension, upload.signingSource || upload.uploadSource)

--- a/services/consumer/lanes.js
+++ b/services/consumer/lanes.js
@@ -1,0 +1,91 @@
+'use strict'
+// Ingest lane topology + routing (2026-07-14, rfcx-local).
+//
+// Mirrors the analysis-tier lane design (pm_queue_lib.py) for the ingest tier.
+// A "router" stage consumes the legacy ingest-service-upload-production queue,
+// reads the upload's laneTier from Mongo, and re-publishes each S3-event to the
+// matching lane queue; the weighted multi-lane consumer then drains the lanes.
+//
+// Lane tiers (laneTier on the Mongo StreamUpload doc, default "standard"):
+//   express   -> ingest.work.express.0..E-1   (small/fast uploads jump ahead)
+//   priority  -> ingest.work.priority.0..P-1  (paid/priority; WEIGHTED, not
+//                                               strict -> standard never starves)
+//   standard  -> ingest.work.0..N-1           (the fair lanes, round-robin)
+// Legacy ingest-service-upload-production is kept as the ROUTER's input queue
+// (rfcx-api still publishes there, untouched) + a rollback drain.
+//
+// All queue topology (quorum, DLX, delivery-limit) is declared in
+// rfcx-local platform/rabbitmq/definitions.json and applied at bootstrap; here
+// we only NAME the queues + do passive checkQueue (never assertQueue).
+
+const LANE_COUNT = parseInt(process.env.INGEST_LANE_COUNT || '10', 10)
+const EXPRESS_COUNT = parseInt(process.env.INGEST_EXPRESS_COUNT || '2', 10)
+const PRIORITY_COUNT = parseInt(process.env.INGEST_PRIORITY_COUNT || '2', 10)
+
+// Base name for the lane family. The router's INPUT is the legacy queue.
+const LANE_BASE = process.env.INGEST_LANE_BASE || 'ingest.work'
+const LEGACY_QUEUE = process.env.RABBITMQ_INGEST_TRIGGER_QUEUE || 'ingest-service-upload-production'
+
+const TIERS = ['express', 'priority', 'standard']
+
+function fairLane (i) { return `${LANE_BASE}.${i}` }
+function expressLane (i) { return `${LANE_BASE}.express.${i}` }
+function priorityLane (i) { return `${LANE_BASE}.priority.${i}` }
+
+function fairLanes () { return Array.from({ length: LANE_COUNT }, (_, i) => fairLane(i)) }
+function expressLanes () { return Array.from({ length: EXPRESS_COUNT }, (_, i) => expressLane(i)) }
+function priorityLanes () { return Array.from({ length: PRIORITY_COUNT }, (_, i) => priorityLane(i)) }
+
+// Normalise a laneTier value -> canonical tier. Unknown/empty -> "standard".
+function normaliseTier (tier) {
+  const t = (tier || '').toString().trim().toLowerCase()
+  return TIERS.includes(t) ? t : 'standard'
+}
+
+// The list of lanes for a tier (used by the router to pick a target lane).
+function lanesForTier (tier) {
+  switch (normaliseTier(tier)) {
+    case 'express': return expressLanes()
+    case 'priority': return priorityLanes()
+    default: return fairLanes()
+  }
+}
+
+// All lanes the CONSUMER drains, in NO particular order (ordering/weighting is
+// the consumer's scan loop, not this list). Includes the legacy queue LAST as a
+// rollback/in-flight drain.
+function allLanes () {
+  return [...expressLanes(), ...priorityLanes(), ...fairLanes(), LEGACY_QUEUE]
+}
+
+// Pick a target lane for a message of `tier`, given current lane depths, using
+// least-loaded + random tie-break (mirrors least_loaded_fair_queue: keeps two
+// simultaneous messages off the same lane instead of always stacking lane 0).
+// `depthOf(lane) -> integer` is provided by the caller (from checkQueue).
+function pickLane (tier, depthOf) {
+  const lanes = lanesForTier(tier)
+  if (lanes.length === 0) { return fairLane(0) }
+  let lo = Infinity
+  for (const l of lanes) { const d = depthOf(l); if (d < lo) { lo = d } }
+  const mins = lanes.filter((l) => depthOf(l) === lo)
+  return mins[Math.floor(Math.random() * mins.length)]
+}
+
+module.exports = {
+  LANE_COUNT,
+  EXPRESS_COUNT,
+  PRIORITY_COUNT,
+  LANE_BASE,
+  LEGACY_QUEUE,
+  TIERS,
+  fairLane,
+  expressLane,
+  priorityLane,
+  fairLanes,
+  expressLanes,
+  priorityLanes,
+  normaliseTier,
+  lanesForTier,
+  allLanes,
+  pickLane
+}

--- a/services/consumer/rabbitmq.js
+++ b/services/consumer/rabbitmq.js
@@ -1,28 +1,64 @@
+// `stopped` is mutated by amqp connection/channel 'close' event handlers, which
+// eslint's static loop analysis can't see -> disable the false-positive rule.
+/* eslint-disable no-unmodified-loop-condition */
 const amqplib = require('amqplib')
 const { ingest } = require('../rfcx/ingest')
 const { parseUploadFromFileName } = require('./misc')
 const TimeTracker = require('../../utils/time-tracker')
 const db = require('../db/mongo')
+const lanes = require('./lanes')
 
 const { flacLimitSize, wavLimitSize } = require('../../utils/limits')
 
-const queueName = process.env.RABBITMQ_INGEST_TRIGGER_QUEUE || 'ingest-service-upload-production'
 const url = process.env.RABBITMQ_URL || process.env.AMQP_URL
 
-// Same S3-event payload shape that SQS receives from AWS S3 event notifications;
-// this lets an s3-cache/s3-writer publisher and AWS S3 both feed compatible bodies.
-//   { Records: [ { eventName: "ObjectCreated:Put",
-//                  s3: { bucket: { name, arn }, object: { key, size } } } ] }
+// ---------------------------------------------------------------------------
+// Multi-lane weighted consumer (2026-07-14, rfcx-local).
+//
+// The upload work is spread across lane queues (services/consumer/lanes.js):
+//   express.0..E-1  -> checked FIRST each cycle (small/fast uploads)
+//   priority.0..P-1 -> WEIGHTED: serviced W times per standard visit, but
+//                      standard is ALWAYS serviced once per cycle, so priority
+//                      is faster WITHOUT starving standard (weighted RR, not
+//                      strict priority).
+//   standard 0..N-1 -> the fair lanes, rotating round-robin.
+//   legacy queue    -> rollback / in-flight drain, LAST.
+//
+// Pull-based (channel.get) rotating scan, mirroring the analysis pm_consume.py
+// design: push-subscribe (channel.consume) cannot enforce cross-queue ordering
+// or weighting, so we pull-when-ready. prefetch is irrelevant for get(); we
+// process one file at a time (unchanged from the previous single-queue prefetch=1).
+//
+// priority_weight W is a LIVE rfcxctl knob (rfcxctl:ingest:priority_weight,
+// default 3): "for every 1 standard chunk served, serve up to W priority chunks".
+// Fractional-credit accumulation lets W be non-integer + de-syncs consumers.
+// ---------------------------------------------------------------------------
+
+const POLL_IDLE_MS = parseInt(process.env.INGEST_POLL_IDLE_MS || '500', 10)
+const PRIORITY_WEIGHT_DEFAULT = parseFloat(process.env.INGEST_PRIORITY_WEIGHT || '3')
+// Cap the priority inner-drain per cycle so express stays responsive even under
+// a priority flood (never spend unbounded time before re-checking express).
+const PRIORITY_MAX_PER_CYCLE = parseInt(process.env.INGEST_PRIORITY_MAX_PER_CYCLE || '8', 10)
+
+// Priority weight W. Env-configurable (INGEST_PRIORITY_WEIGHT, default 3).
+// LIVE rfcxctl tuning (rfcxctl:ingest:priority_weight, like the analysis
+// express/prefetch knobs) is a documented follow-up: it needs a redis client
+// dependency the ingest-service image doesn't currently carry, so for now the
+// weight is a static env (restart to change). The weighted-RR mechanism itself
+// is fully live; only the knob's live-tunability is deferred.
+async function priorityWeight () {
+  return PRIORITY_WEIGHT_DEFAULT
+}
+
+// Same S3-event payload shape that SQS receives; the router re-publishes the
+// identical body onto a lane queue, so parsing is unchanged.
 function parseIngestRecords (body) {
   try {
     const filesS3Paths = []
     body.Records.forEach((record) => {
       if (record.eventName && record.eventName.includes('ObjectCreated:')) {
         filesS3Paths.push({
-          bucket: {
-            name: record.s3.bucket.name,
-            arn: record.s3.bucket.arn
-          },
+          bucket: { name: record.s3.bucket.name, arn: record.s3.bucket.arn },
           key: record.s3.object.key,
           size: record.s3.object.size
         })
@@ -34,6 +70,7 @@ function parseIngestRecords (body) {
   }
 }
 
+// Returns true => ack, false => nack-no-requeue (DLX). Unchanged logic.
 async function handleMessage (body) {
   let tracker = new TimeTracker('IngestConsumer')
   const files = parseIngestRecords(body)
@@ -46,18 +83,9 @@ async function handleMessage (body) {
       } else if (fileExtension === 'wav' && file.size > wavLimitSize) {
         db.updateUploadStatus(uploadId, db.status.FAILED, `This wav file size is exceeding our limit (${wavLimitSize / 1_000_000}MB)`)
       } else {
-        // ingest() RESOLVES for both success and "handled terminal"
-        // outcomes (duplicate / already-ingested / checksum mismatch /
-        // unsupported / size) — those are fully recorded against the
-        // upload and re-processing will never resolve them, so we ACK-drop
-        // them rather than flooding the DLQ. It only THROWS on transient /
-        // unexpected failures, which we nack-no-requeue to the DLX below.
         await ingest(file.key, fileLocalPath, streamId, uploadId)
       }
     } catch (e) {
-      // returning false nacks the message; nack-no-requeue routes to DLX
-      // (matching SQS-without-redrive semantics). Reserved for transient /
-      // unexpected failures worth inspecting/redriving.
       console.error(`[${uploadId}] Nacking message to DLQ: ${e && e.message}`)
       return false
     }
@@ -67,110 +95,136 @@ async function handleMessage (body) {
   return true
 }
 
-// Direct amqplib consumer.
-//
-// We do NOT call assertQueue here. The queue topology
-// (durable, x-queue-type=quorum, x-dead-letter-exchange=dlx,
-// x-dead-letter-routing-key, x-delivery-limit) is owned by
-// the rfcx-local platform via platform/rabbitmq/definitions.json
-// and applied at cluster bootstrap. Calling assertQueue with
-// a different argument set causes PRECONDITION_FAILED.
-//
-// Instead, we use checkQueue (passive declare): it fails if
-// the queue does not exist, but does not conflict with the
-// existing arguments. The publisher side has the same rule.
-// Reconnect tuning (env-overridable). Backoff grows linearly per attempt up
-// to a cap, so a brief RabbitMQ blip recovers in seconds while a longer outage
-// doesn't hammer the broker.
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Process one raw amqp message (get() result) through handleMessage + ack/nack.
+async function processMessage (channel, msg) {
+  let body
+  try {
+    body = JSON.parse(msg.content.toString('utf8'))
+  } catch (e) {
+    console.error('Ingest RabbitMQ: bad JSON, nacking:', e && e.message)
+    channel.nack(msg, false, false)
+    return
+  }
+  try {
+    const result = await handleMessage(body)
+    if (result === false) { channel.nack(msg, false, false) } else { channel.ack(msg) }
+  } catch (e) {
+    console.error('Ingest RabbitMQ: handler threw, nacking:', e && e.message)
+    channel.nack(msg, false, false)
+  }
+}
+
 const RECONNECT_BASE_MS = parseInt(process.env.RABBITMQ_RECONNECT_BASE_MS || '2000', 10)
 const RECONNECT_MAX_MS = parseInt(process.env.RABBITMQ_RECONNECT_MAX_MS || '30000', 10)
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-
-// Establish ONE connection + channel + consumer. Resolves once the consumer is
-// subscribed; rejects if any step fails (so connectWithRetry can retry). On a
-// LATER drop (connection/channel 'close' after we were subscribed) we trigger a
-// fresh reconnect loop instead of process.exit(1): a RabbitMQ restart otherwise
-// crash-loops the whole consumer fleet AND (the bug this fixes) the INITIAL
-// connect failure used to become an unhandled rejection that left the pod up
-// but silently NOT consuming (looked healthy, queue stalled at 0 consumers).
-async function connectOnce () {
-  let reconnecting = false
-  const scheduleReconnect = (why) => {
-    if (reconnecting) { return }
-    reconnecting = true
-    console.error(`Ingest RabbitMQ ${why}; reconnecting...`)
-    // Detach from the current (dead) connection and start a fresh retry loop.
-    connectWithRetry().catch((e) => {
-      console.error('Ingest RabbitMQ reconnect loop failed fatally; exiting', e && e.message)
-      process.exit(1)
-    })
-  }
+// Establish a connection + channel, verify all lane queues exist (passive), and
+// run the weighted rotating scan loop until the connection/channel drops.
+async function consumeLoop () {
+  const expressLanes = lanes.expressLanes()
+  const priorityLanes = lanes.priorityLanes()
+  const fairLanes = lanes.fairLanes()
+  const legacy = lanes.LEGACY_QUEUE
 
   const connection = await amqplib.connect(url)
-  connection.on('error', (err) => {
-    console.error('Ingest RabbitMQ connection error', err && err.message)
-  })
-  connection.on('close', () => scheduleReconnect('connection closed'))
-  let channel
-  try {
-    channel = await connection.createChannel()
-    channel.on('error', (err) => {
-      console.error('Ingest RabbitMQ channel error', err && err.message)
-    })
-    channel.on('close', () => scheduleReconnect('channel closed'))
-    await channel.checkQueue(queueName) // passive; fails if not pre-declared
-    await channel.prefetch(1)
-  } catch (e) {
-    // Channel/queue setup failed on an otherwise-open connection: close it so we
-    // don't leak connections across retries (the 'close' handler is suppressed
-    // by re-throwing before any successful subscribe, so connectWithRetry owns
-    // the retry). Guard close() since it can itself throw if already dead.
-    reconnecting = true // prevent the close handler from double-scheduling
-    try { await connection.close() } catch (_) { /* already closing/closed */ }
-    throw e
+  let stopped = false
+  const stop = () => { stopped = true }
+  connection.on('error', (err) => console.error('Ingest RabbitMQ connection error', err && err.message))
+  connection.on('close', stop)
+
+  const channel = await connection.createChannel()
+  channel.on('error', (err) => console.error('Ingest RabbitMQ channel error', err && err.message))
+  channel.on('close', stop)
+
+  // Passive verify every lane exists (topology owned by definitions.json).
+  for (const q of lanes.allLanes()) {
+    await channel.checkQueue(q) // throws PRECONDITION/NOT_FOUND -> caller retries
   }
-  await channel.consume(queueName, async (msg) => {
-    if (msg === null) { return } // consumer cancelled by server
-    let body
-    try {
-      body = JSON.parse(msg.content.toString('utf8'))
-    } catch (e) {
-      console.error('Ingest RabbitMQ: bad JSON, nacking:', e && e.message)
-      channel.nack(msg, false, false)
-      return
+
+  console.info(`Ingest RabbitMQ multi-lane consumer up: express=${expressLanes.length} priority=${priorityLanes.length} fair=${fairLanes.length} (+legacy) weight~${PRIORITY_WEIGHT_DEFAULT}`)
+
+  let expressPtr = 0
+  let priorityPtr = 0
+  let fairPtr = 0
+  let priorityCredit = 0
+
+  // get one message from a queue; null if empty. noAck=false so we ack/nack.
+  const getFrom = async (q) => {
+    const msg = await channel.get(q, { noAck: false })
+    return msg || null // amqplib returns false when empty
+  }
+
+  while (!stopped) {
+    let didWork = false
+
+    // 1) EXPRESS first (rotating over express lanes) — tiny, always checked.
+    for (let i = 0; i < expressLanes.length && !stopped; i++) {
+      const q = expressLanes[expressPtr]
+      expressPtr = (expressPtr + 1) % expressLanes.length
+      const msg = await getFrom(q)
+      if (msg) { await processMessage(channel, msg); didWork = true; break }
     }
-    try {
-      const result = await handleMessage(body)
-      if (result === false) {
-        channel.nack(msg, false, false)
-      } else {
-        channel.ack(msg)
+    if (stopped) { break }
+    if (didWork) { continue } // re-check express before anything else
+
+    // 2) PRIORITY — WEIGHTED. Accrue W credits/cycle; serve up to floor(credit)
+    //    priority messages (capped), rotating over priority lanes. Standard
+    //    (step 3) is ALWAYS served once below regardless -> no starvation.
+    const W = await priorityWeight()
+    priorityCredit += W
+    let served = 0
+    while (priorityCredit >= 1 && served < PRIORITY_MAX_PER_CYCLE && !stopped) {
+      let got = false
+      for (let i = 0; i < priorityLanes.length; i++) {
+        const q = priorityLanes[priorityPtr]
+        priorityPtr = (priorityPtr + 1) % priorityLanes.length
+        const msg = await getFrom(q)
+        if (msg) { await processMessage(channel, msg); priorityCredit -= 1; served += 1; got = true; didWork = true; break }
       }
-    } catch (e) {
-      console.error('Ingest RabbitMQ: handler threw, nacking:', e && e.message)
-      channel.nack(msg, false, false)
+      if (!got) { break } // priority empty; drop leftover credit at cycle end
     }
-  })
-  console.info(`Ingest RabbitMQ consumer subscribed to queue "${queueName}"`)
+    // Leftover credits do NOT bank across cycles (no future starvation).
+    if (priorityCredit > W) { priorityCredit = W }
+    if (stopped) { break }
+
+    // 3) STANDARD — exactly ONE fair-lane message per cycle (rotating). This is
+    //    the starvation floor: standard always advances even under a priority
+    //    flood.
+    for (let i = 0; i < fairLanes.length && !stopped; i++) {
+      const q = fairLanes[fairPtr]
+      fairPtr = (fairPtr + 1) % fairLanes.length
+      const msg = await getFrom(q)
+      if (msg) { await processMessage(channel, msg); didWork = true; break }
+    }
+    if (stopped) { break }
+
+    // 4) LEGACY drain (rollback / in-flight), only when nothing else had work.
+    if (!didWork) {
+      const msg = await getFrom(legacy)
+      if (msg) { await processMessage(channel, msg); didWork = true }
+    }
+
+    if (!didWork) { await sleep(POLL_IDLE_MS) } // idle: back off politely
+  }
+
+  try { await channel.close() } catch (_) {}
+  try { await connection.close() } catch (_) {}
+  throw new Error('consume loop ended (connection/channel closed)')
 }
 
-// Retry connectOnce() with capped linear backoff until it succeeds. This is the
-// core of the fix: neither the initial connect nor a later drop can leave the
-// pod running-but-not-consuming. (Liveness is still bounded by the fatal exit
-// in scheduleReconnect's catch, which only fires if the retry loop itself
-// throws synchronously — connectWithRetry never resolves-as-failed otherwise.)
+// Retry consumeLoop() with capped linear backoff. Neither an initial connect
+// failure nor a later drop leaves the pod running-but-not-consuming.
 async function connectWithRetry () {
   let attempt = 0
   // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
-      await connectOnce()
-      return
+      await consumeLoop()
     } catch (e) {
       attempt += 1
       const delay = Math.min(RECONNECT_BASE_MS * attempt, RECONNECT_MAX_MS)
-      console.error(`Ingest RabbitMQ connect attempt ${attempt} failed (${e && e.message}); retrying in ${delay}ms`)
+      console.error(`Ingest RabbitMQ loop attempt ${attempt} ended (${e && e.message}); retrying in ${delay}ms`)
       await sleep(delay)
     }
   }
@@ -183,4 +237,4 @@ async function start () {
   await connectWithRetry()
 }
 
-module.exports = { start }
+module.exports = { start, handleMessage }

--- a/services/consumer/router.js
+++ b/services/consumer/router.js
@@ -1,0 +1,148 @@
+'use strict'
+// Ingest lane ROUTER (2026-07-14, rfcx-local).
+//
+// Consumes the LEGACY queue (ingest-service-upload-production, fed unchanged by
+// rfcx-api after the R2->CF->api chain), looks up the upload's laneTier from
+// Mongo (keyed by the uploadId embedded in the S3 object key), and RE-PUBLISHES
+// the identical S3-event body onto the matching lane queue. The weighted
+// multi-lane consumer (rabbitmq.js) then drains the lanes.
+//
+// Why a router (not publish-from-rfcx-api): keeps ALL lane logic in
+// ingest-service; rfcx-api / the R2->api producer path is untouched.
+//
+// Safe to run in EVERY tasks pod: RabbitMQ delivers each legacy message to
+// exactly one consumer, so N routers just share the load (no duplication).
+// Re-publish is idempotent enough (a message lands on exactly one lane; if the
+// router crashes after publish-before-ack, the legacy message redelivers and
+// the file is re-published to a lane -> the consumer's ingest() is itself
+// duplicate-safe, same as before).
+
+// `stopped` is mutated by amqp connection/channel 'close' event handlers, which
+// eslint's static loop analysis can't see -> disable the false-positive rule.
+/* eslint-disable no-unmodified-loop-condition */
+const amqplib = require('amqplib')
+const db = require('../db/mongo')
+const lanes = require('./lanes')
+const { parseUploadFromFileName } = require('./misc')
+
+const url = process.env.RABBITMQ_URL || process.env.AMQP_URL
+const LEGACY = lanes.LEGACY_QUEUE
+const ROUTER_ENABLED = (process.env.INGEST_LANE_ROUTER || 'on').toLowerCase() !== 'off'
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const RECONNECT_BASE_MS = parseInt(process.env.RABBITMQ_RECONNECT_BASE_MS || '2000', 10)
+const RECONNECT_MAX_MS = parseInt(process.env.RABBITMQ_RECONNECT_MAX_MS || '30000', 10)
+
+// Extract the uploadId from the FIRST ObjectCreated record's key, so we can
+// look up its laneTier. All records in one message share a laneTier in practice
+// (one upload per event); we route the whole message by the first.
+function firstUploadId (body) {
+  try {
+    for (const record of body.Records || []) {
+      if (record.eventName && record.eventName.includes('ObjectCreated:')) {
+        const { uploadId } = parseUploadFromFileName(record.s3.object.key)
+        return uploadId
+      }
+    }
+  } catch (_) {}
+  return null
+}
+
+async function laneTierForBody (body) {
+  const uploadId = firstUploadId(body)
+  if (!uploadId) { return 'standard' }
+  try {
+    const upload = await db.getUpload(uploadId)
+    return lanes.normaliseTier(upload && upload.laneTier)
+  } catch (_) {
+    // Upload not found / DB blip -> fail safe to standard (never drop).
+    return 'standard'
+  }
+}
+
+async function routerLoop () {
+  const connection = await amqplib.connect(url)
+  let stopped = false
+  const stop = () => { stopped = true }
+  connection.on('error', (e) => console.error('Ingest router connection error', e && e.message))
+  connection.on('close', stop)
+
+  const channel = await connection.createChannel()
+  channel.on('error', (e) => console.error('Ingest router channel error', e && e.message))
+  channel.on('close', stop)
+
+  // passive-verify the legacy input + confirm at least the fair lanes exist
+  await channel.checkQueue(LEGACY)
+  for (const q of [...lanes.expressLanes(), ...lanes.priorityLanes(), ...lanes.fairLanes()]) {
+    await channel.checkQueue(q)
+  }
+  // publisher confirms so a re-publish that the broker didn't accept nacks the
+  // source message (no silent loss).
+  await channel.confirmSelect()
+  await channel.prefetch(20) // small pipeline; routing is cheap
+
+  // depth cache for least-loaded lane selection (refreshed opportunistically).
+  const depthCache = new Map()
+  const depthOf = (q) => (depthCache.has(q) ? depthCache.get(q) : 0)
+  const refreshDepths = async (tier) => {
+    for (const q of lanes.lanesForTier(tier)) {
+      try { const ok = await channel.checkQueue(q); depthCache.set(q, ok.messageCount) } catch (_) {}
+    }
+  }
+
+  console.info(`Ingest lane router up: legacy="${LEGACY}" -> express/priority/fair lanes`)
+
+  await channel.consume(LEGACY, async (msg) => {
+    if (msg === null) { return }
+    let body
+    try {
+      body = JSON.parse(msg.content.toString('utf8'))
+    } catch (e) {
+      console.error('Ingest router: bad JSON on legacy queue, nacking:', e && e.message)
+      channel.nack(msg, false, false)
+      return
+    }
+    try {
+      const tier = await laneTierForBody(body)
+      await refreshDepths(tier)
+      const target = lanes.pickLane(tier, depthOf)
+      // Re-publish the identical body to the target lane (default exchange,
+      // routing_key = queue name). Persistent, wait for confirm.
+      channel.sendToQueue(target, msg.content, { persistent: true, contentType: 'application/json' })
+      await channel.waitForConfirms()
+      // bump local depth so a burst of same-tier messages spreads across lanes
+      depthCache.set(target, depthOf(target) + 1)
+      channel.ack(msg)
+    } catch (e) {
+      // publish/confirm failed -> nack-requeue so the legacy message is retried
+      // (transient broker issue); do NOT DLX (nothing wrong with the message).
+      console.error('Ingest router: publish failed, requeueing:', e && e.message)
+      try { channel.nack(msg, false, true) } catch (_) {}
+    }
+  })
+
+  // idle wait until the connection drops
+  while (!stopped) { await sleep(1000) }
+  try { await channel.close() } catch (_) {}
+  try { await connection.close() } catch (_) {}
+  throw new Error('router loop ended (connection/channel closed)')
+}
+
+async function startRouter () {
+  if (!ROUTER_ENABLED) { console.info('Ingest lane router disabled (INGEST_LANE_ROUTER=off)'); return }
+  if (!url) { throw new Error('RABBITMQ_URL/AMQP_URL required for the ingest lane router') }
+  let attempt = 0
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      await routerLoop()
+    } catch (e) {
+      attempt += 1
+      const delay = Math.min(RECONNECT_BASE_MS * attempt, RECONNECT_MAX_MS)
+      console.error(`Ingest router loop attempt ${attempt} ended (${e && e.message}); retrying in ${delay}ms`)
+      await sleep(delay)
+    }
+  }
+}
+
+module.exports = { startRouter, laneTierForBody, firstUploadId }

--- a/services/db/models/mongoose/upload.js
+++ b/services/db/models/mongoose/upload.js
@@ -15,6 +15,12 @@ const UploadSchema = new mongoose.Schema({
   sampleRate: Number,
   targetBitrate: Number,
   checksum: String,
+  // rfcx-local lane tier (2026-07-14): which ingest lane group this upload's
+  // work is routed to by the lane router. One of express|priority|standard;
+  // defaults to standard. The criteria that CHOOSE the tier live in the upload
+  // registration endpoint (routes/uploads.js); this field is the persisted
+  // decision the router reads.
+  laneTier: { type: String, default: 'standard' },
   uploadSource: {
     targetId: String,
     targetVersion: Number,

--- a/services/db/mongo.js
+++ b/services/db/mongo.js
@@ -10,7 +10,7 @@ const status = { WAITING: 0, UPLOADED: 10, INGESTED: 20, FAILED: 30, DUPLICATE: 
 const statusNumbers = Object.values(status)
 
 function generateUpload (opts) {
-  const { streamId, userId, timestamp, originalFilename, fileExtension, sampleRate, targetBitrate, checksum, projectId, duration, uploadTarget } = opts
+  const { streamId, userId, timestamp, originalFilename, fileExtension, sampleRate, targetBitrate, checksum, projectId, duration, uploadTarget, laneTier } = opts
 
   const upload = new UploadModel({
     streamId,
@@ -22,7 +22,11 @@ function generateUpload (opts) {
     originalFilename,
     sampleRate,
     targetBitrate,
-    checksum
+    checksum,
+    // rfcx-local lane tier: express|priority|standard, default standard.
+    laneTier: ['express', 'priority', 'standard'].includes((laneTier || '').toLowerCase())
+      ? laneTier.toLowerCase()
+      : 'standard'
   })
 
   const id = upload._id


### PR DESCRIPTION
Adds fair/express/priority **lane tiers** to the ingest tier, mirroring the rfcx-local analysis-tier lane design. Uploads can be prioritised so a single big batch doesn't head-of-line-block others, and a paid/priority tier is serviced faster **without starving standard** (weighted round-robin, not strict priority).

## Design (all lane logic stays in ingest-service; rfcx-api / the R2→api producer path is untouched)
The producer keeps publishing to the legacy queue `ingest-service-upload-production`. A **router** stage inside the tasks pod consumes that, looks up the upload's `laneTier` from Mongo, and re-publishes onto the matching lane queue; the **weighted multi-lane consumer** drains the lanes.

- **`routes/uploads.js`** — accept optional `laneTier` (express|priority|standard, default standard) via a single `deriveLaneTier()` hook = THE place to add selection criteria later (small-file→express, paid-project→priority). For now honours an explicit request else standard.
- **`services/db/{mongo,models/mongoose/upload}.js`** — persist `laneTier` on the StreamUpload doc.
- **`services/consumer/lanes.js`** (new) — lane topology + least-loaded-with-random-tie-break routing.
- **`services/consumer/router.js`** (new) — legacy→Mongo-lookup→republish (publisher-confirmed, nack-requeue on failure — never drops). Safe in every pod (RabbitMQ delivers each legacy msg once).
- **`services/consumer/rabbitmq.js`** — single-queue push-subscribe → **pull-based rotating scan**: express-first → priority (weighted: accrue W credits/cycle, serve up to floor(credit), capped) → **exactly one standard fair-lane per cycle** (the starvation floor) → legacy. Weighted, not strict.

## Weighting
`W = INGEST_PRIORITY_WEIGHT` (default 3): for every 1 standard chunk served, up to W priority chunks are served — priority is ~W× faster when both are busy, but standard always advances (step 3 serves one fair lane every cycle regardless). Idle tiers cost nothing. Live rfcxctl tuning of W is a follow-up (needs a redis client dep the image doesn't carry yet).

## Ops
- Queue topology (14 lanes + DLQs, quorum/DLX/delivery-limit + no-TTL policy) is declared in rfcx-local `platform/rabbitmq/definitions.json` and imported live. Consumer uses passive `checkQueue` (never `assertQueue`) — same contract as before.
- Env knobs: `INGEST_LANE_COUNT`(10) / `INGEST_EXPRESS_COUNT`(2) / `INGEST_PRIORITY_COUNT`(2) / `INGEST_PRIORITY_WEIGHT`(3) / `INGEST_LANE_ROUTER`(on).
- **Backward-compatible + rollback-safe:** the consumer also drains the legacy queue last; `INGEST_LANE_ROUTER=off` reverts to pure legacy flow.
- lint + `node --check` clean.