### PR TITLE
fix(ingest): fail open on 5xx from upload-limit-summary (not just 404)

### DIFF
--- a/services/rfcx/arbimon.js
+++ b/services/rfcx/arbimon.js
@@ -13,22 +13,30 @@ function getProjectUploadLimitSummary (idToken, projectId) {
   return axios.get(url, { headers })
     .then(response => response.data)
     .catch(e => {
-      // Graceful degradation: if the project's upload-limit endpoint isn't
-      // available (404 — the route is in biodiversity-api 'develop' but not
-      // yet in 'master', so the deployed image may not have it; or the
-      // project doesn't exist in biodiversity-api's DB at all), treat the
-      // project as having NO upload limit configured. This matches the
-      // semantics of `recordingMinutesLimit: null` further up the call
-      // chain (assertProjectUploadWithinLimit in routes/uploads.js).
+      // Graceful degradation: the upload-limit / quota check is BEST-EFFORT.
+      // It exists to refuse uploads to view-only / over-quota projects; if
+      // the quota can't be determined we treat the project as having NO
+      // upload limit configured (recordingMinutesLimit: null, matching
+      // assertProjectUploadWithinLimit in routes/uploads.js) and ALLOW the
+      // upload. Failing CLOSED here breaks otherwise-valid uploads whenever
+      // the quota dependency is unhealthy — which was the production
+      // behaviour on 2026-05-19 right after the Phase 3 ingest cutover.
       //
-      // The check exists to refuse uploads to view-only / over-quota
-      // projects; missing endpoint is interpreted as 'no quota information
-      // available, allow the upload'. The alternative (failing closed)
-      // breaks all uploads when the dependency is out of sync, which is
-      // both worse user experience and was the production behavior on
-      // 2026-05-19 immediately after the Phase 3 ingest cutover landed.
-      if (e && e.response && e.response.status === 404) {
-        console.warn('[arbimon] upload-limit-summary endpoint returned 404 for project ' + projectId + '; treating as unlimited.')
+      // Two fail-open classes:
+      //   404  — the biodiversity-api route isn't deployed, or the project
+      //          doesn't exist in its DB.
+      //   5xx  — the quota chain is unhealthy. In particular the summary
+      //          proxies to the LEGACY arbimon2 `/project/:slug/tiering-usage`
+      //          endpoint, whose session layer resolves the caller by email;
+      //          a caller without an email claim (e.g. a machine/system
+      //          token) makes that legacy hop 500. That legacy dependency is
+      //          being retired (mysql2pg #40) — until then, a 5xx from the
+      //          quota check must NOT block a valid upload. Real end-user
+      //          tokens carry an email and enforce quota normally; this only
+      //          fails open when the quota service itself can't answer.
+      const status = e && e.response && e.response.status
+      if (status === 404 || (typeof status === 'number' && status >= 500)) {
+        console.warn('[arbimon] upload-limit-summary returned ' + status + ' for project ' + projectId + '; treating as unlimited (fail-open).')
         return { isLocked: false, recordingMinutesLimit: null, recordingMinutesCount: 0 }
       }
       throw matchAxiosErrorToRfcx(e)

--- a/services/rfcx/arbimon.test.js
+++ b/services/rfcx/arbimon.test.js
@@ -1,0 +1,45 @@
+const axios = require('../../utils/axios')
+
+jest.mock('../../utils/axios')
+
+const { getProjectUploadLimitSummary } = require('./arbimon')
+
+const UNLIMITED = { isLocked: false, recordingMinutesLimit: null, recordingMinutesCount: 0 }
+
+describe('getProjectUploadLimitSummary', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  test('returns the summary payload on success', async () => {
+    const summary = { isLocked: false, recordingMinutesLimit: 6000, recordingMinutesCount: 120 }
+    axios.get.mockResolvedValue({ data: summary })
+    await expect(getProjectUploadLimitSummary('Bearer t', 'proj1')).resolves.toEqual(summary)
+  })
+
+  test('fails open (unlimited) on 404 — endpoint/project not present', async () => {
+    axios.get.mockRejectedValue({ response: { status: 404 } })
+    await expect(getProjectUploadLimitSummary('Bearer t', 'proj1')).resolves.toEqual(UNLIMITED)
+  })
+
+  test('fails open (unlimited) on 500 — quota chain unhealthy (e.g. legacy email-session on a machine token)', async () => {
+    axios.get.mockRejectedValue({ response: { status: 500 } })
+    await expect(getProjectUploadLimitSummary('Bearer t', 'proj1')).resolves.toEqual(UNLIMITED)
+  })
+
+  test('fails open (unlimited) on 503 — dependency down', async () => {
+    axios.get.mockRejectedValue({ response: { status: 503 } })
+    await expect(getProjectUploadLimitSummary('Bearer t', 'proj1')).resolves.toEqual(UNLIMITED)
+  })
+
+  test('does NOT fail open on 401 — real auth failure propagates', async () => {
+    axios.get.mockRejectedValue({ response: { status: 401 }, message: 'Unauthorized' })
+    await expect(getProjectUploadLimitSummary('Bearer t', 'proj1')).rejects.toBeDefined()
+  })
+
+  test('does NOT fail open on 403 — forbidden propagates', async () => {
+    axios.get.mockRejectedValue({ response: { status: 403 }, message: 'Forbidden' })
+    await expect(getProjectUploadLimitSummary('Bearer t', 'proj1')).rejects.toBeDefined()
+  })
+})


### PR DESCRIPTION
## What

The upload quota check (`getProjectUploadLimitSummary`) is **best-effort** — it refuses uploads to view-only / over-quota projects, and already **fails open** (treats the project as unlimited) on a `404`. This extends the same fail-open to **5xx**.

## Why

Surfaced during the in-browser bulk uploader prod E2E (2026-07-16). `upload-limit-summary` (biodiversity-api) proxies to the **legacy** arbimon2 `/project/:slug/tiering-usage` endpoint, whose session layer resolves the caller **by email** (`login.js` → `findByEmail(req.user.email)`). A caller with no email claim — e.g. a machine/system token — makes that legacy hop `500` (`WHERE parameter "email" has invalid "undefined" value`).

Failing **closed** on that blocks an otherwise-valid upload. That's the same class of outage we hit 2026-05-19 right after the Phase 3 ingest cutover, which is exactly why the 404 fail-open exists. The legacy `tiering-usage` dependency is being retired (mysql2pg #40); until then a 5xx from the quota chain must not block uploads.

**Real end-user tokens carry an email and enforce quota normally** — this only fails open when the quota service itself can't answer. `401`/`403` still propagate (real auth failures are not masked).

## Tests

New `services/rfcx/arbimon.test.js`: success passthrough; fail-open on 404/500/503; propagate on 401/403. All green; eslint clean.

## Deploy

rfcx-local CD builds ingest-service from `master`; merge → CD rolls `ingest-service-api` + `ingest-service-tasks`.