### PR TITLE
feat(upload): presigned multipart upload endpoints (browser large-file path)

### DIFF
--- a/routes/uploads.int.test.js
+++ b/routes/uploads.int.test.js
@@ -5,7 +5,7 @@ const originalEnv = { ...process.env }
 
 const storageModulePath = '../services/storage/amazon'
 jest.mock(storageModulePath)
-const { getSignedUrl } = require(storageModulePath)
+const { getSignedUrl, createMultipartUpload, getSignedPartUrls, completeMultipartUpload, abortMultipartUpload } = require(storageModulePath)
 
 const streamsModulePath = '../services/rfcx/streams'
 jest.mock(streamsModulePath)
@@ -45,6 +45,10 @@ beforeEach(async () => {
   }))
   getExistingSourceFile.mockImplementation(() => { throw new EmptyResultError('Stream source file not found') })
   getSignedUrl.mockImplementation(() => 'http://some.url')
+  createMultipartUpload.mockImplementation(async () => 'mp-upload-id-1')
+  getSignedPartUrls.mockImplementation(async (path, mpId, partNumbers) => partNumbers.map(partNumber => ({ partNumber, url: `http://part.url/${partNumber}` })))
+  completeMultipartUpload.mockImplementation(async () => ({}))
+  abortMultipartUpload.mockImplementation(async () => ({}))
   await truncateDbModels(UploadModel)
 })
 afterEach(async () => {
@@ -53,6 +57,10 @@ afterEach(async () => {
   getProjectUploadLimitSummary.mockRestore()
   getExistingSourceFile.mockRestore()
   getSignedUrl.mockRestore()
+  createMultipartUpload.mockRestore()
+  getSignedPartUrls.mockRestore()
+  completeMultipartUpload.mockRestore()
+  abortMultipartUpload.mockRestore()
   process.env = { ...originalEnv }
 })
 afterAll(async () => {
@@ -1119,5 +1127,128 @@ describe('GET /uploads/:id', () => {
     expect(response.body.sampleRate).toEqual(12000)
     expect(response.body.targetBitrate).toEqual(2921629)
     expect(response.body.checksum).toEqual('b40e6a5687c7ce2557ce48e131cc68c2889bfdc2')
+  })
+})
+
+describe('POST /uploads/multipart', () => {
+  const validBody = {
+    filename: 'bigfile-2021-06-08T19-26-40.flac',
+    timestamp: '2021-06-08T19:26:40.000Z',
+    stream: '0a1824085e3f',
+    duration: 3600000,
+    fileSize: 200 * 1024 * 1024, // 200MB -> 4 parts at default 64MB
+    sampleRate: 48000
+  }
+
+  test('registers the upload and returns per-part signed urls', async () => {
+    const response = await request(app).post('/uploads/multipart').send(validBody)
+    expect(response.statusCode).toBe(200)
+    expect(response.body.uploadId).toBeDefined()
+    expect(response.body.multipartUploadId).toEqual('mp-upload-id-1')
+    expect(response.body.partCount).toEqual(4)
+    expect(response.body.partUrls).toHaveLength(4)
+    expect(response.body.partUrls[0]).toEqual({ partNumber: 1, url: 'http://part.url/1' })
+    const upload = await UploadModel.findById(response.body.uploadId)
+    expect(upload.multipart.uploadId).toEqual('mp-upload-id-1')
+    expect(upload.multipart.partCount).toEqual(4)
+    expect(upload.status).toEqual(status.WAITING)
+  })
+
+  test('rejects files below the multipart minimum', async () => {
+    const response = await request(app).post('/uploads/multipart').send({ ...validBody, fileSize: 10 * 1024 * 1024 })
+    expect(response.statusCode).toBe(400)
+    expect(response.body.message).toContain('Multipart is for files')
+  })
+
+  test('requires fileSize', async () => {
+    const { fileSize, ...withoutSize } = validBody
+    const response = await request(app).post('/uploads/multipart').send(withoutSize)
+    expect(response.statusCode).toBe(400)
+  })
+
+  test('applies the same duplicate check as single uploads', async () => {
+    getExistingSourceFile.mockImplementation(async () => ({
+      availability: 1,
+      segments: [{ start: '2021-06-08T19:26:40.000Z' }]
+    }))
+    const response = await request(app).post('/uploads/multipart').send({ ...validBody, checksum: 'acd44fdcc42e0dad141f35ae1aa029fd6b3f9eca' })
+    expect(response.statusCode).toBe(400)
+    expect(response.body.message).toContain('Duplicate')
+  })
+})
+
+describe('POST /uploads/:id/multipart/complete', () => {
+  const makeMultipartUpload = async (overrides = {}) => {
+    return await new UploadModel({
+      streamId: '0a1824085e3f',
+      userId: seedValues.primaryUserGuid,
+      status: status.WAITING,
+      timestamp: '2021-06-08T19:26:40.000Z',
+      originalFilename: 'bigfile.flac',
+      multipart: { uploadId: 'mp-upload-id-1', partSizeBytes: 64 * 1024 * 1024, partCount: 2 },
+      uploadSource: { targetId: 't1', bucket: 'streams-uploads', key: '0a1824085e3f/x.flac' },
+      ...overrides
+    }).save()
+  }
+
+  test('completes with valid parts', async () => {
+    const dbUpload = await makeMultipartUpload()
+    const response = await request(app).post(`/uploads/${dbUpload._id}/multipart/complete`).send({
+      parts: [{ partNumber: 1, etag: '"etag1"' }, { partNumber: 2, etag: '"etag2"' }]
+    })
+    expect(response.statusCode).toBe(200)
+    expect(response.body.completed).toBe(true)
+    expect(completeMultipartUpload).toHaveBeenCalledTimes(1)
+    const refreshed = await UploadModel.findById(dbUpload._id)
+    expect(refreshed.multipart.completedAt).toBeDefined()
+  })
+
+  test('is idempotent when already completed', async () => {
+    const dbUpload = await makeMultipartUpload({ multipart: { uploadId: 'mp-upload-id-1', partSizeBytes: 1, partCount: 1, completedAt: new Date() } })
+    const response = await request(app).post(`/uploads/${dbUpload._id}/multipart/complete`).send({
+      parts: [{ partNumber: 1, etag: '"etag1"' }]
+    })
+    expect(response.statusCode).toBe(200)
+    expect(completeMultipartUpload).not.toHaveBeenCalled()
+  })
+
+  test('rejects malformed parts', async () => {
+    const dbUpload = await makeMultipartUpload()
+    const response = await request(app).post(`/uploads/${dbUpload._id}/multipart/complete`).send({ parts: [{ partNumber: 'x' }] })
+    expect(response.statusCode).toBe(400)
+  })
+
+  test('403 for a different user', async () => {
+    const dbUpload = await makeMultipartUpload({ userId: seedValues.otherUserGuid })
+    const response = await request(app).post(`/uploads/${dbUpload._id}/multipart/complete`).send({
+      parts: [{ partNumber: 1, etag: '"etag1"' }]
+    })
+    expect(response.statusCode).toBe(403)
+  })
+
+  test('404 when no multipart in progress', async () => {
+    const dbUpload = await makeMultipartUpload({ multipart: undefined })
+    const response = await request(app).post(`/uploads/${dbUpload._id}/multipart/complete`).send({
+      parts: [{ partNumber: 1, etag: '"etag1"' }]
+    })
+    expect(response.statusCode).toBe(404)
+  })
+})
+
+describe('POST /uploads/:id/multipart/abort', () => {
+  test('aborts an in-progress multipart upload', async () => {
+    const dbUpload = await new UploadModel({
+      streamId: '0a1824085e3f',
+      userId: seedValues.primaryUserGuid,
+      status: status.WAITING,
+      timestamp: '2021-06-08T19:26:40.000Z',
+      originalFilename: 'bigfile.flac',
+      multipart: { uploadId: 'mp-upload-id-1', partSizeBytes: 1, partCount: 1 },
+      uploadSource: { targetId: 't1', bucket: 'streams-uploads', key: '0a1824085e3f/x.flac' }
+    }).save()
+    const response = await request(app).post(`/uploads/${dbUpload._id}/multipart/abort`).send({})
+    expect(response.statusCode).toBe(200)
+    expect(response.body.aborted).toBe(true)
+    expect(abortMultipartUpload).toHaveBeenCalledTimes(1)
   })
 })

--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -119,7 +119,9 @@ async function parseUploadParams (body) {
   return validateUploadParams(params)
 }
 
-async function createSignedUpload (rawParams, { req, idToken, userId }) {
+// Shared registration: validation, permission, quota, dedup, target selection
+// and the Mongo upload doc. Used by both the single-PUT and multipart flows.
+async function registerUpload (rawParams, { req, idToken, userId }) {
   const params = await parseUploadParams(rawParams)
 
   if (!auth0Service.getRoles(req.user).includes('systemUser')) {
@@ -175,11 +177,62 @@ async function createSignedUpload (rawParams, { req, idToken, userId }) {
     uploadTarget,
     laneTier
   })
+  return { upload, params, fileExtension }
+}
+
+async function createSignedUpload (rawParams, { req, idToken, userId }) {
+  const { upload, fileExtension } = await registerUpload(rawParams, { req, idToken, userId })
   const uploadId = upload.id
   const url = await storage.getSignedUrl(upload.path, 'audio/' + fileExtension, upload.signingSource || upload.uploadSource)
   return {
     uploadId,
     url,
+    path: upload.path,
+    bucket: upload.uploadSource?.bucket || process.env.UPLOAD_BUCKET,
+    uploadTargetId: upload.uploadSource?.targetId
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Presigned multipart upload (2026-07-16, browser large-file path).
+//
+// Part sizing: fixed server-chosen size so the client cannot pick pathological
+// values. S3/R2 constraints: parts 5MB..5GB (last part may be smaller), max
+// 10,000 parts. With 64MB parts a 1GiB FLAC is 16 parts; well within limits.
+// ---------------------------------------------------------------------------
+const MULTIPART_PART_SIZE_BYTES = Number(process.env.MULTIPART_PART_SIZE_BYTES || 64 * 1024 * 1024)
+const MULTIPART_MIN_FILE_BYTES = Number(process.env.MULTIPART_MIN_FILE_BYTES || 100 * 1024 * 1024)
+const MULTIPART_MAX_PARTS = 10000
+
+async function createMultipartSignedUpload (rawParams, { req, idToken, userId }) {
+  if (!rawParams || !rawParams.fileSize) {
+    throw new ValidationError('fileSize is required for multipart uploads.')
+  }
+  const fileSize = Number(rawParams.fileSize)
+  if (fileSize < MULTIPART_MIN_FILE_BYTES) {
+    throw new ValidationError(`Multipart is for files >= ${MULTIPART_MIN_FILE_BYTES / 1_000_000}MB; use POST /uploads for smaller files.`)
+  }
+  const partCount = Math.ceil(fileSize / MULTIPART_PART_SIZE_BYTES)
+  if (partCount > MULTIPART_MAX_PARTS) {
+    throw new ValidationError('File is too large for the configured part size.')
+  }
+
+  const { upload, fileExtension } = await registerUpload(rawParams, { req, idToken, userId })
+  const uploadId = upload.id
+  const signingSource = upload.signingSource || upload.uploadSource
+  const contentType = 'audio/' + fileExtension
+
+  const multipartUploadId = await storage.createMultipartUpload(upload.path, contentType, signingSource)
+  await db.setUploadMultipart(uploadId, { uploadId: multipartUploadId, partSizeBytes: MULTIPART_PART_SIZE_BYTES, partCount })
+  const partNumbers = Array.from({ length: partCount }, (_, i) => i + 1)
+  const partUrls = await storage.getSignedPartUrls(upload.path, multipartUploadId, partNumbers, signingSource)
+
+  return {
+    uploadId,
+    multipartUploadId,
+    partSizeBytes: MULTIPART_PART_SIZE_BYTES,
+    partCount,
+    partUrls,
     path: upload.path,
     bucket: upload.uploadSource?.bucket || process.env.UPLOAD_BUCKET,
     uploadTargetId: upload.uploadSource?.targetId
@@ -314,6 +367,116 @@ router.route('/').post((req, res) => {
       res.json(upload)
     })
     .catch(httpErrorHandler(req, res, 'Failed creating an upload.'))
+})
+
+/**
+ * @swagger
+ *
+ * /uploads/multipart:
+ *   post:
+ *        summary: Registers a large upload and returns presigned part URLs
+ *        description: Same validation/permission/quota/dedup as POST /uploads, but for large files. Returns one presigned PUT URL per part (server-chosen part size). The client PUTs each part (collecting ETags) then calls /uploads/{id}/multipart/complete.
+ *        tags:
+ *          - uploads
+ *        responses:
+ *          200:
+ *            description: Multipart upload descriptor with per-part signed URLs
+ *          400:
+ *            description: Invalid parameters (or file too small for multipart)
+ *          401:
+ *            description: Unauthorized
+ *          503:
+ *            description: Upload creation is paused
+ */
+router.route('/multipart').post((req, res) => {
+  if (`${process.env.CREATION_PAUSED}` === 'true') {
+    return res.status(503).json({ message: 'Server is on maintenance. Creating new uploads is paused. Try again later.' })
+  }
+  const idToken = req.headers.authorization
+  const userId = req.user.guid || req.user.sub || 'unknown'
+
+  createMultipartSignedUpload(req.body, { req, idToken, userId })
+    .then((upload) => { res.json(upload) })
+    .catch(httpErrorHandler(req, res, 'Failed creating a multipart upload.'))
+})
+
+/**
+ * @swagger
+ *
+ * /uploads/{id}/multipart/complete:
+ *   post:
+ *        summary: Completes a multipart upload
+ *        description: Server-side CompleteMultipartUpload with the client-collected part ETags. R2 fires its ObjectCreated event on completion, triggering ingestion exactly like a single PUT.
+ *        tags:
+ *          - uploads
+ *        responses:
+ *          200:
+ *            description: Completed
+ *          400:
+ *            description: Invalid parts payload
+ *          403:
+ *            description: Not the upload owner
+ *          404:
+ *            description: Unknown upload / no multipart in progress
+ */
+router.route('/:id/multipart/complete').post((req, res) => {
+  const id = req.params.id
+  const parts = req.body && req.body.parts
+  if (!Array.isArray(parts) || parts.length < 1 || !parts.every(p => p && Number.isInteger(p.partNumber) && typeof p.etag === 'string' && p.etag.length > 0)) {
+    return httpErrorHandler(req, res, 'Failed completing multipart upload.')(new ValidationError("Parameter 'parts' must be a non-empty array of { partNumber, etag }."))
+  }
+
+  return Promise.resolve().then(async () => {
+    const upload = assertUploadStatusAccess(req, await db.getUpload(id))
+    if (!upload.multipart || !upload.multipart.uploadId) {
+      throw new EmptyResultError('No multipart upload in progress for this upload id.')
+    }
+    if (upload.multipart.completedAt) {
+      // Idempotent: repeated completes (e.g. client retry after a timeout)
+      return res.json({ uploadId: id, completed: true })
+    }
+    // The object key lives on the persisted uploadSource (fetched docs have
+    // no top-level `path`); legacy fallback derives it from streamId + id.
+    const fallbackKey = `${upload.streamId}/${upload._id}.${(upload.originalFilename || '').split('.').pop().toLowerCase()}`
+    const source = uploadTargets.sourceFromUpload(upload, fallbackKey)
+    await storage.completeMultipartUpload(source.key || fallbackKey, upload.multipart.uploadId, parts, source)
+    await db.setUploadMultipartCompleted(id)
+    res.json({ uploadId: id, completed: true })
+  }).catch(httpErrorHandler(req, res, 'Failed completing multipart upload.'))
+})
+
+/**
+ * @swagger
+ *
+ * /uploads/{id}/multipart/abort:
+ *   post:
+ *        summary: Aborts a multipart upload and frees its stored parts
+ *        tags:
+ *          - uploads
+ *        responses:
+ *          200:
+ *            description: Aborted
+ *          403:
+ *            description: Not the upload owner
+ *          404:
+ *            description: Unknown upload / no multipart in progress
+ */
+router.route('/:id/multipart/abort').post((req, res) => {
+  const id = req.params.id
+  return Promise.resolve().then(async () => {
+    const upload = assertUploadStatusAccess(req, await db.getUpload(id))
+    if (!upload.multipart || !upload.multipart.uploadId) {
+      throw new EmptyResultError('No multipart upload in progress for this upload id.')
+    }
+    if (upload.multipart.abortedAt || upload.multipart.completedAt) {
+      return res.json({ uploadId: id, aborted: Boolean(upload.multipart.abortedAt) })
+    }
+    const fallbackKey = `${upload.streamId}/${upload._id}.${(upload.originalFilename || '').split('.').pop().toLowerCase()}`
+    const source = uploadTargets.sourceFromUpload(upload, fallbackKey)
+    await storage.abortMultipartUpload(source.key || fallbackKey, upload.multipart.uploadId, source)
+    await db.setUploadMultipartAborted(id)
+    res.json({ uploadId: id, aborted: true })
+  }).catch(httpErrorHandler(req, res, 'Failed aborting multipart upload.'))
 })
 
 /**

--- a/services/db/models/mongoose/upload.js
+++ b/services/db/models/mongoose/upload.js
@@ -34,6 +34,15 @@ const UploadSchema = new mongoose.Schema({
   },
   uploadSourceDeletedAt: Date,
   uploadSourceCleanupMessage: String,
+  // Presigned multipart upload state (2026-07-16, browser large-file path).
+  // Present only for multipart uploads; single-PUT uploads never set it.
+  multipart: {
+    uploadId: String, // the S3/R2 multipart UploadId
+    partSizeBytes: Number,
+    partCount: Number,
+    completedAt: Date,
+    abortedAt: Date
+  },
   ingestionResult: {
     streamSourceFileId: String,
     streamId: String,

--- a/services/db/mongo.js
+++ b/services/db/mongo.js
@@ -81,6 +81,18 @@ function getUpload (id) {
     })
 }
 
+function setUploadMultipart (uploadId, multipart) {
+  return UploadModel.updateOne({ _id: uploadId }, { $set: { multipart, updatedAt: new Date() } })
+}
+
+function setUploadMultipartCompleted (uploadId) {
+  return UploadModel.updateOne({ _id: uploadId }, { $set: { 'multipart.completedAt': new Date(), updatedAt: new Date() } })
+}
+
+function setUploadMultipartAborted (uploadId) {
+  return UploadModel.updateOne({ _id: uploadId }, { $set: { 'multipart.abortedAt': new Date(), updatedAt: new Date() } })
+}
+
 function updateUploadStatus (uploadId, statusNumber, failureMessage = null, ingestionResult = null) {
   if (!statusNumbers.includes(statusNumber)) {
     throw new Error('Invalid status')
@@ -180,6 +192,9 @@ function getOrCreateHealthCheck () {
 module.exports = {
   generateUpload,
   getPendingProjectDuration,
+  setUploadMultipart,
+  setUploadMultipartCompleted,
+  setUploadMultipartAborted,
   getUpload,
   getUploadDuplicateCount,
   getUploadFailedCount,

--- a/services/storage/amazon.js
+++ b/services/storage/amazon.js
@@ -102,6 +102,63 @@ function getSignedUrl (filePath, contentType, source) {
   }))
 }
 
+// ---------------------------------------------------------------------------
+// Presigned MULTIPART upload (browser large-file path, 2026-07-16).
+// S3-compatible multipart against the upload bucket (R2 supports the full
+// Create/UploadPart/Complete/Abort set). The service signs per-part PUT URLs
+// so the client never holds credentials; Complete/Abort are performed
+// server-side (they are cheap control-plane calls and R2's event rule fires
+// on CompleteMultipartUpload, keeping the ingestion trigger unchanged).
+// ---------------------------------------------------------------------------
+
+function createMultipartUpload (filePath, contentType, source) {
+  const params = {
+    Bucket: source?.bucket || uploadBucket,
+    Key: source?.key || filePath,
+    ContentType: contentType
+  }
+  const client = uploadClientForSource(source)
+  return client.createMultipartUpload(params).promise().then(data => data.UploadId)
+}
+
+function getSignedPartUrls (filePath, multipartUploadId, partNumbers, source) {
+  const client = uploadClientForSource(source)
+  const bucket = source?.bucket || uploadBucket
+  const key = source?.key || filePath
+  return Promise.all(partNumbers.map(partNumber => new Promise((resolve, reject) => {
+    client.getSignedUrl('uploadPart', {
+      Bucket: bucket,
+      Key: key,
+      UploadId: multipartUploadId,
+      PartNumber: partNumber,
+      Expires: 60 * 60 * 24 // 24 hours, matches single-PUT expiry
+    }, (err, url) => {
+      if (err) { reject(err) } else { resolve({ partNumber, url }) }
+    })
+  })))
+}
+
+function completeMultipartUpload (filePath, multipartUploadId, parts, source) {
+  const client = uploadClientForSource(source)
+  return client.completeMultipartUpload({
+    Bucket: source?.bucket || uploadBucket,
+    Key: source?.key || filePath,
+    UploadId: multipartUploadId,
+    MultipartUpload: {
+      Parts: parts.map(part => ({ PartNumber: part.partNumber, ETag: part.etag }))
+    }
+  }).promise()
+}
+
+function abortMultipartUpload (filePath, multipartUploadId, source) {
+  const client = uploadClientForSource(source)
+  return client.abortMultipartUpload({
+    Bucket: source?.bucket || uploadBucket,
+    Key: source?.key || filePath,
+    UploadId: multipartUploadId
+  }).promise()
+}
+
 function download (remotePath, localPath, source) {
   const bucket = source?.bucket || uploadBucket
   const key = source?.key || remotePath
@@ -191,6 +248,10 @@ function deleteObject (Bucket, Key) {
 
 module.exports = {
   getSignedUrl,
+  createMultipartUpload,
+  getSignedPartUrls,
+  completeMultipartUpload,
+  abortMultipartUpload,
   download,
   upload,
   createFromData,


### PR DESCRIPTION
## What

Adds S3/R2 **presigned multipart** support for large files — the P3 hardening from the browser bulk-uploader design (rfcx-local `runbooks/DESIGN-browser-bulk-uploader-2026-07-16.md` §G6).

- `POST /uploads/multipart` — same validation/permission/quota/dedup pipeline as `POST /uploads` (extracted shared `registerUpload()`), returns one presigned PUT URL per part. **Server-chosen part size** (`MULTIPART_PART_SIZE_BYTES`, default 64MB) so clients can't pick pathological values; gated to files ≥ `MULTIPART_MIN_FILE_BYTES` (default 100MB); 10k-part cap.
- `POST /uploads/:id/multipart/complete` — server-side `CompleteMultipartUpload` with client-collected part ETags. Idempotent on repeat (client retry safety). **R2 fires ObjectCreated on completion, so the entire ingestion trigger chain (event → queue → bridge → RabbitMQ lanes → tasks) is unchanged** — the R2 event rules already listen for `CompleteMultipartUpload`.
- `POST /uploads/:id/multipart/abort` — frees stored parts (bucket abort-rule remains the orphan backstop).
- Ownership on complete/abort enforced via the same `assertUploadStatusAccess` as the status APIs.
- Mongo upload doc gains an optional `multipart` subdoc; single-PUT uploads are untouched.

## Why

A single presigned PUT is all-or-nothing: a dropped connection at 95% of a 1GB FLAC re-sends the entire file — genuinely painful on the flaky field connectivity our users have. With parts, only the in-flight part retries.

## Tests
10 new integration tests; full uploads suite 62/62 green; eslint clean. (audio.test.js Can split/Can convert fail pre-existing on this machine — ffmpeg env, unrelated.)

## Client
Engine-side support (part-splitting pool, ETag collection, per-part retry) lands next in `@rfcx-bio/upload-engine` (rfcx/arbimon).