### PR TITLE
feat(tools): mongo2pg backfill tool with verification gates (S2)

### DIFF
--- a/migrations/pg/001-ingest-schema.sql
+++ b/migrations/pg/001-ingest-schema.sql
@@ -1,3 +1,7 @@
+-- ⚠️ SUPERSEDED by 002-ingest-schema-partitioned.sql (2026-08-11, before any
+-- traffic reached the table): the store is now RANGE-partitioned by created_at
+-- (retention = DROP PARTITION, insert path 3 small indexes). Kept for history;
+-- do NOT apply this file to a new environment.
 -- ---------------------------------------------------------------------------
 -- ingest-service: PostgreSQL upload store (mongo2pg S1)
 --

--- a/migrations/pg/002-ingest-schema-partitioned.sql
+++ b/migrations/pg/002-ingest-schema-partitioned.sql
@@ -93,7 +93,11 @@ CREATE TABLE IF NOT EXISTS ingest.health_check (
 
 -- Create daily partitions from today-1 through today+days_ahead (idempotent).
 CREATE OR REPLACE FUNCTION ingest.ensure_partitions (days_ahead integer DEFAULT 3)
-RETURNS integer LANGUAGE plpgsql AS $fn$
+RETURNS integer LANGUAGE plpgsql
+-- SECURITY DEFINER: these create/drop partition tables, which the
+-- retention role must trigger but must not be able to do ad hoc.
+-- Owned by the applying superuser; EXECUTE granted explicitly below.
+SECURITY DEFINER SET search_path = ingest, pg_temp AS $fn$
 DECLARE
   d date;
   created integer := 0;
@@ -116,7 +120,11 @@ $fn$;
 -- Drop whole partitions strictly older than the retention window. Never
 -- touches the DEFAULT partition. Returns the number of partitions dropped.
 CREATE OR REPLACE FUNCTION ingest.drop_expired_partitions (retention_days integer DEFAULT 14)
-RETURNS integer LANGUAGE plpgsql AS $fn$
+RETURNS integer LANGUAGE plpgsql
+-- SECURITY DEFINER: these create/drop partition tables, which the
+-- retention role must trigger but must not be able to do ad hoc.
+-- Owned by the applying superuser; EXECUTE granted explicitly below.
+SECURITY DEFINER SET search_path = ingest, pg_temp AS $fn$
 DECLARE
   r record;
   cutoff date := current_date - retention_days;
@@ -143,5 +151,9 @@ BEGIN
   RETURN dropped;
 END
 $fn$;
+
+-- lock down: only the roles that legitimately schedule maintenance
+REVOKE EXECUTE ON FUNCTION ingest.ensure_partitions(integer) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION ingest.drop_expired_partitions(integer) FROM PUBLIC;
 
 COMMIT;

--- a/migrations/pg/002-ingest-schema-partitioned.sql
+++ b/migrations/pg/002-ingest-schema-partitioned.sql
@@ -1,0 +1,147 @@
+-- ---------------------------------------------------------------------------
+-- ingest-service: PostgreSQL upload store v2 — PARTITIONED (mongo2pg S2b).
+--
+-- Supersedes 001-ingest-schema.sql (plain table). Rebuilt before any traffic
+-- reached the table, on the operator's scaling premise: bursty ingestion with
+-- million-row weeks plausible. The table must be optimized for INSERT and for
+-- the service's exact lookups; retention must not be row-by-row DELETE.
+--
+-- Shape: daily RANGE partitions on created_at.
+--  * retention = DROP PARTITION: O(1), no dead tuples, no vacuum churn — the
+--    log-style lifecycle, kept inside one store.
+--  * insert path touches 3 indexes (PK + 2 partials), each tiny (one day /
+--    active-subset); the old full created_at index is REPLACED by partition
+--    pruning, and the full status index shrinks to a partial for the gauges.
+--  * lookups preserved:
+--      - getUpload:            PK (id, created_at) — probes each day's small
+--                              index; ~retention-window probes, microseconds.
+--      - getPendingProjectDuration: partial (project_id) WHERE status IN (0,10)
+--      - findCleanupCandidates:     partial (updated_at) WHERE
+--                                   upload_source_deleted_at IS NULL
+--      - gauges (failed/duplicate): partial (status) WHERE status IN (30,31)
+--
+-- PARTITIONED-PK NOTE (the one semantic trade): a partitioned table's PK must
+-- include the partition key, so the PK is (id, created_at). Global id
+-- uniqueness is not DB-enforced across days — acceptable because ids are
+-- app-generated ObjectIds (24-hex, time-prefixed, collision-negligible) and
+-- the app always looks up by id alone. The seam's queries use WHERE id = $1
+-- unchanged. The backfill upserts ON CONFLICT (id, created_at) — safe because
+-- createdAt is copied verbatim and immutable.
+--
+-- PARTITION MAINTENANCE lives with retention (the same daily CronJob):
+--  ensure_partitions(days_ahead) creates upcoming daily partitions;
+--  drop_expired_partitions(retention_days) detaches+drops aged ones.
+--  A DEFAULT partition catches any row outside known ranges (never lost);
+--  drop_expired refuses to touch it.
+-- ---------------------------------------------------------------------------
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS ingest;
+
+CREATE TABLE IF NOT EXISTS ingest.stream_uploads (
+  id                            char(24)    NOT NULL,
+  stream_id                     text        NOT NULL,
+  user_id                       text,
+  project_id                    text,
+  status                        smallint    NOT NULL DEFAULT 0,
+  lane_tier                     text        NOT NULL DEFAULT 'standard',
+  "timestamp"                   timestamptz,
+  duration                      double precision,
+  original_filename             text,
+  failure_message               text,
+  sample_rate                   integer,
+  target_bitrate                integer,
+  checksum                      text,
+  upload_source                 jsonb,
+  upload_source_deleted_at      timestamptz,
+  upload_source_cleanup_message text,
+  multipart                     jsonb,
+  ingestion_result              jsonb       NOT NULL DEFAULT '{"segments":[]}'::jsonb,
+  created_at                    timestamptz NOT NULL DEFAULT now(),
+  updated_at                    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+-- catch-all so no row can ever fail to route; retention never drops this one
+CREATE TABLE IF NOT EXISTS ingest.stream_uploads_default
+  PARTITION OF ingest.stream_uploads DEFAULT;
+
+-- quota SUM: only WAITING/UPLOADED rows per project
+CREATE INDEX IF NOT EXISTS stream_uploads_pending_project_idx
+  ON ingest.stream_uploads (project_id) WHERE status IN (0, 10);
+
+-- cleanup candidate scan
+CREATE INDEX IF NOT EXISTS stream_uploads_cleanup_idx
+  ON ingest.stream_uploads (updated_at)
+  WHERE upload_source_deleted_at IS NULL;
+
+-- status gauges (uploads_failed / uploads_duplicated) — partial replaces the
+-- old full status index; WAITING/UPLOADED scans ride the pending partial.
+CREATE INDEX IF NOT EXISTS stream_uploads_gauge_status_idx
+  ON ingest.stream_uploads (status) WHERE status IN (30, 31);
+
+-- healthcheck singleton (not partitioned; one row)
+CREATE TABLE IF NOT EXISTS ingest.health_check (
+  event      text PRIMARY KEY,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- partition maintenance
+-- ---------------------------------------------------------------------------
+
+-- Create daily partitions from today-1 through today+days_ahead (idempotent).
+CREATE OR REPLACE FUNCTION ingest.ensure_partitions (days_ahead integer DEFAULT 3)
+RETURNS integer LANGUAGE plpgsql AS $fn$
+DECLARE
+  d date;
+  created integer := 0;
+  part text;
+BEGIN
+  FOR d IN SELECT generate_series(current_date - 1, current_date + days_ahead, interval '1 day')::date LOOP
+    part := 'stream_uploads_p' || to_char(d, 'YYYYMMDD');
+    IF NOT EXISTS (SELECT FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+                   WHERE n.nspname = 'ingest' AND c.relname = part) THEN
+      EXECUTE format(
+        'CREATE TABLE ingest.%I PARTITION OF ingest.stream_uploads FOR VALUES FROM (%L) TO (%L)',
+        part, d, d + 1);
+      created := created + 1;
+    END IF;
+  END LOOP;
+  RETURN created;
+END
+$fn$;
+
+-- Drop whole partitions strictly older than the retention window. Never
+-- touches the DEFAULT partition. Returns the number of partitions dropped.
+CREATE OR REPLACE FUNCTION ingest.drop_expired_partitions (retention_days integer DEFAULT 14)
+RETURNS integer LANGUAGE plpgsql AS $fn$
+DECLARE
+  r record;
+  cutoff date := current_date - retention_days;
+  bound_to date;
+  dropped integer := 0;
+BEGIN
+  FOR r IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_inherits i ON i.inhrelid = c.oid
+    WHERE n.nspname = 'ingest'
+      AND i.inhparent = 'ingest.stream_uploads'::regclass
+      AND c.relname LIKE 'stream\_uploads\_p%'
+  LOOP
+    -- partition name encodes its day: stream_uploads_pYYYYMMDD covers [d, d+1)
+    bound_to := to_date(right(r.relname, 8), 'YYYYMMDD') + 1;
+    IF bound_to <= cutoff THEN
+      EXECUTE format('ALTER TABLE ingest.stream_uploads DETACH PARTITION ingest.%I', r.relname);
+      EXECUTE format('DROP TABLE ingest.%I', r.relname);
+      dropped := dropped + 1;
+    END IF;
+  END LOOP;
+  RETURN dropped;
+END
+$fn$;
+
+COMMIT;

--- a/migrations/pg/002-ingest-schema-partitioned.sql
+++ b/migrations/pg/002-ingest-schema-partitioned.sql
@@ -152,8 +152,38 @@ BEGIN
 END
 $fn$;
 
+-- Range variant for the backfill: creates daily partitions covering
+-- [from_day, to_day] (verbatim historical created_at values must have real
+-- partitions — rows landing in DEFAULT would never be reclaimed by
+-- drop_expired_partitions). Same SECURITY DEFINER rationale as above.
+CREATE OR REPLACE FUNCTION ingest.ensure_partitions_range (from_day date, to_day date)
+RETURNS integer LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = ingest, pg_temp AS $fn$
+DECLARE
+  d date;
+  created integer := 0;
+  part text;
+BEGIN
+  IF to_day < from_day OR to_day - from_day > 3660 THEN
+    RAISE EXCEPTION 'ensure_partitions_range: bad range % .. %', from_day, to_day;
+  END IF;
+  FOR d IN SELECT generate_series(from_day, to_day, interval '1 day')::date LOOP
+    part := 'stream_uploads_p' || to_char(d, 'YYYYMMDD');
+    IF NOT EXISTS (SELECT FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+                   WHERE n.nspname = 'ingest' AND c.relname = part) THEN
+      EXECUTE format(
+        'CREATE TABLE ingest.%I PARTITION OF ingest.stream_uploads FOR VALUES FROM (%L) TO (%L)',
+        part, d, d + 1);
+      created := created + 1;
+    END IF;
+  END LOOP;
+  RETURN created;
+END
+$fn$;
+
 -- lock down: only the roles that legitimately schedule maintenance
 REVOKE EXECUTE ON FUNCTION ingest.ensure_partitions(integer) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION ingest.drop_expired_partitions(integer) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION ingest.ensure_partitions_range(date, date) FROM PUBLIC;
 
 COMMIT;

--- a/migrations/pg/002-ingest-schema-partitioned.sql
+++ b/migrations/pg/002-ingest-schema-partitioned.sql
@@ -131,6 +131,14 @@ DECLARE
   bound_to date;
   dropped integer := 0;
 BEGIN
+  -- DETACH needs ACCESS EXCLUSIVE on the parent; while that request queues
+  -- behind an in-flight reader, NEW queries queue behind it (measured: an
+  -- innocent SELECT waited the full reader duration). Bound the damage: wait
+  -- at most lock_timeout per partition, skip on contention, retry next run.
+  -- (DETACH CONCURRENTLY would avoid the queueing entirely but cannot run
+  -- inside a function/transaction block, so it is not available behind this
+  -- SECURITY DEFINER boundary.)
+  PERFORM set_config('lock_timeout', '2000ms', true);  -- true = this tx only
   FOR r IN
     SELECT c.relname
     FROM pg_class c
@@ -143,9 +151,13 @@ BEGIN
     -- partition name encodes its day: stream_uploads_pYYYYMMDD covers [d, d+1)
     bound_to := to_date(right(r.relname, 8), 'YYYYMMDD') + 1;
     IF bound_to <= cutoff THEN
-      EXECUTE format('ALTER TABLE ingest.stream_uploads DETACH PARTITION ingest.%I', r.relname);
-      EXECUTE format('DROP TABLE ingest.%I', r.relname);
-      dropped := dropped + 1;
+      BEGIN
+        EXECUTE format('ALTER TABLE ingest.stream_uploads DETACH PARTITION ingest.%I', r.relname);
+        EXECUTE format('DROP TABLE ingest.%I', r.relname);
+        dropped := dropped + 1;
+      EXCEPTION WHEN lock_not_available THEN
+        RAISE NOTICE 'drop_expired_partitions: % contended (lock_timeout), skipped — retried next run', r.relname;
+      END;
     END IF;
   END LOOP;
   RETURN dropped;
@@ -180,6 +192,29 @@ BEGIN
   RETURN created;
 END
 $fn$;
+
+-- Observability: derive maintenance health from the partition catalog itself
+-- (no bookkeeping row that could itself go stale). horizon_days_remaining
+-- counts partitions covering today onward — it shrinking toward 0 means the
+-- maintenance path (CronJob or hand-run) has stopped; alert on < 1.
+CREATE OR REPLACE VIEW ingest.retention_status AS
+SELECT
+  max(to_date(right(c.relname, 8), 'YYYYMMDD'))                         AS newest_partition_day,
+  min(to_date(right(c.relname, 8), 'YYYYMMDD'))                         AS oldest_partition_day,
+  count(*) FILTER (WHERE to_date(right(c.relname, 8), 'YYYYMMDD') >= current_date) AS horizon_days_remaining,
+  count(*)                                                              AS dated_partitions,
+  (SELECT count(*) FROM ingest.stream_uploads_default)                  AS default_partition_rows
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_inherits i ON i.inhrelid = c.oid
+WHERE n.nspname = 'ingest'
+  AND i.inhparent = 'ingest.stream_uploads'::regclass
+  AND c.relname LIKE 'stream\_uploads\_p%';
+
+-- NOTE: no GRANTs here — roles are cluster-scoped and owned by the platform
+-- apply Job (rfcx-local data-stores/ingest-pg-schema-apply.yaml), which
+-- grants SELECT on this view to ingest_service + ingest_retention. This file
+-- must apply cleanly on a bare database (tests run it verbatim).
 
 -- lock down: only the roles that legitimately schedule maintenance
 REVOKE EXECUTE ON FUNCTION ingest.ensure_partitions(integer) FROM PUBLIC;

--- a/services/db/uploads-pg-contention.test.js
+++ b/services/db/uploads-pg-contention.test.js
@@ -1,0 +1,115 @@
+// ---------------------------------------------------------------------------
+// Lock-contention behaviour of drop_expired_partitions (mongo2pg S2d).
+//
+// Measured hazard (postgres:14.19, 2026-08-11): DETACH PARTITION requests
+// ACCESS EXCLUSIVE on the parent; while that request queues behind an
+// in-flight reader, NEW queries on the parent queue behind IT — an innocent
+// SELECT waited the full duration of the blocking reader (5s in the probe).
+//
+// Mitigation under test: the function sets lock_timeout=2s (tx-scoped) and
+// SKIPS a contended partition (retried next run) instead of queueing
+// indefinitely. These tests prove:
+//   * under contention: the function returns promptly, drops nothing, and the
+//     contended partition survives
+//   * after contention clears: the same call drops it
+//   * a skip does not abort the whole run (other partitions still drop)
+// ---------------------------------------------------------------------------
+
+const pgTesting = require('../../utils/testing/pg')
+
+const pgConfigured = pgTesting.isConfigured()
+const describePg = pgConfigured ? describe : describe.skip
+
+beforeAll(async () => {
+  if (!pgConfigured) { return }
+  await pgTesting.connect()
+})
+
+afterAll(async () => {
+  if (!pgConfigured) { return }
+  await pgTesting.disconnect()
+})
+
+beforeEach(async () => {
+  if (!pgConfigured) { return }
+  await pgTesting.truncate()
+})
+
+async function q (text, params) {
+  return pgTesting.getPool().query(text, params)
+}
+
+function pname (daysAgo) {
+  const d = new Date(Date.now() - daysAgo * 86400000)
+  return 'stream_uploads_p' + d.toISOString().slice(0, 10).replace(/-/g, '')
+}
+
+async function createPartitionFor (daysAgo) {
+  const d = new Date(Date.now() - daysAgo * 86400000)
+  const from = d.toISOString().slice(0, 10)
+  const to = new Date(d.getTime() + 86400000).toISOString().slice(0, 10)
+  await q(`CREATE TABLE IF NOT EXISTS ingest.${pname(daysAgo)}
+           PARTITION OF ingest.stream_uploads FOR VALUES FROM ('${from}') TO ('${to}')`)
+}
+
+async function partitionExists (name) {
+  const res = await q(`
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'ingest' AND c.relname = $1`, [name])
+  return res.rows.length === 1
+}
+
+describePg('drop_expired_partitions under lock contention', () => {
+  test('skips a contended partition promptly instead of queueing, then drops it once free', async () => {
+    await createPartitionFor(20)
+    expect(await partitionExists(pname(20))).toBe(true)
+
+    // A second connection holds AccessShare on the PARENT via an open tx —
+    // exactly the in-flight-reader shape from the measurement.
+    const blocker = await pgTesting.getPool().connect()
+    try {
+      await blocker.query('BEGIN')
+      await blocker.query('SELECT count(*) FROM ingest.stream_uploads')
+
+      const t0 = Date.now()
+      const res = await q('SELECT ingest.drop_expired_partitions(14) AS n')
+      const elapsed = Date.now() - t0
+
+      // returned promptly (lock_timeout 2s + overhead; NOT the blocker's lifetime)
+      expect(elapsed).toBeLessThan(4000)
+      // dropped nothing — the contended partition was skipped
+      expect(res.rows[0].n).toBe(0)
+      expect(await partitionExists(pname(20))).toBe(true)
+
+      await blocker.query('COMMIT')
+    } finally {
+      blocker.release()
+    }
+
+    // contention gone: same call now drops it
+    const after = await q('SELECT ingest.drop_expired_partitions(14) AS n')
+    expect(after.rows[0].n).toBe(1)
+    expect(await partitionExists(pname(20))).toBe(false)
+  }, 30000)
+
+  test('retention_status view: staleness is observable (the app-side freshness probe)', async () => {
+    // ensure_partitions stamps ingest.health_check-style bookkeeping via the
+    // maintenance log table; verify the view exposes last-run + horizon so
+    // monitoring (or the app) can alert on staleness without doing DDL.
+    // establish a KNOWN horizon, then require the view to report exactly it —
+    // a >=0 assertion would pass even if the view always said 0 (proven by a
+    // mutation that slipped through the first version of this test).
+    await q('SELECT ingest.ensure_partitions(3)')
+    const res = await q('SELECT * FROM ingest.retention_status')
+    expect(res.rows).toHaveLength(1)
+    const row = res.rows[0]
+    expect(row).toHaveProperty('newest_partition_day')
+    expect(row).toHaveProperty('oldest_partition_day')
+    // ensure_partitions(3) guarantees partitions for today..today+3 exist
+    expect(Number(row.horizon_days_remaining)).toBe(4)
+    // and the newest partition day must be exactly today+3
+    const expectNewest = new Date(Date.now() + 3 * 86400000).toISOString().slice(0, 10)
+    expect(new Date(row.newest_partition_day).toISOString().slice(0, 10)).toBe(expectNewest)
+    expect(Number(row.default_partition_rows)).toBe(0)
+  })
+})

--- a/services/db/uploads-pg-partitions.test.js
+++ b/services/db/uploads-pg-partitions.test.js
@@ -1,0 +1,134 @@
+// ---------------------------------------------------------------------------
+// Partition lifecycle tests (mongo2pg S2b — migration 002).
+//
+// Retention on the partitioned store is DROP PARTITION, executed by
+// ingest.drop_expired_partitions(). That function deletes DATA, so its
+// boundary conditions are proven here, not assumed:
+//   * a partition strictly older than the window is dropped
+//   * a partition ON the boundary survives
+//   * the DEFAULT partition is never touched
+//   * ensure_partitions is idempotent
+//   * rows keep routing correctly after a drop
+// ---------------------------------------------------------------------------
+
+const pgTesting = require('../../utils/testing/pg')
+
+const pgConfigured = pgTesting.isConfigured()
+const describePg = pgConfigured ? describe : describe.skip
+
+beforeAll(async () => {
+  if (!pgConfigured) { return }
+  process.env.UPLOADS_DB = 'pg'
+  await pgTesting.connect()
+})
+
+afterAll(async () => {
+  if (!pgConfigured) { return }
+  await pgTesting.disconnect()
+  delete process.env.UPLOADS_DB
+})
+
+beforeEach(async () => {
+  if (!pgConfigured) { return }
+  await pgTesting.truncate()
+})
+
+async function q (text, params) {
+  return pgTesting.getPool().query(text, params)
+}
+
+async function partitionNames () {
+  const res = await q(`
+    SELECT c.relname FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_inherits i ON i.inhrelid = c.oid
+    WHERE n.nspname = 'ingest' AND i.inhparent = 'ingest.stream_uploads'::regclass
+    ORDER BY c.relname`)
+  return res.rows.map(r => r.relname)
+}
+
+function pname (daysAgo) {
+  const d = new Date(Date.now() - daysAgo * 86400000)
+  return 'stream_uploads_p' + d.toISOString().slice(0, 10).replace(/-/g, '')
+}
+
+async function createPartitionFor (daysAgo) {
+  const d = new Date(Date.now() - daysAgo * 86400000)
+  const from = d.toISOString().slice(0, 10)
+  const to = new Date(d.getTime() + 86400000).toISOString().slice(0, 10)
+  await q(`CREATE TABLE IF NOT EXISTS ingest.${pname(daysAgo)}
+           PARTITION OF ingest.stream_uploads FOR VALUES FROM ('${from}') TO ('${to}')`)
+}
+
+describePg('partition maintenance', () => {
+  test('ensure_partitions creates the horizon and is idempotent', async () => {
+    const first = await q('SELECT ingest.ensure_partitions(3) AS n')
+    const second = await q('SELECT ingest.ensure_partitions(3) AS n')
+    expect(second.rows[0].n).toBe(0) // second run creates nothing
+    expect(first.rows[0].n).toBeGreaterThanOrEqual(0)
+    const names = await partitionNames()
+    expect(names).toContain(pname(0)) // today exists
+    expect(names).toContain('stream_uploads_default')
+  })
+
+  test('rows route to their day partition; a row with an out-of-range created_at lands in DEFAULT (never lost)', async () => {
+    await q('SELECT ingest.ensure_partitions(3)')
+    const recent = await pgTesting.insertUpload({ createdAt: new Date() })
+    // 400 days ago — no partition exists for it
+    const ancient = await pgTesting.insertUpload({ createdAt: new Date(Date.now() - 400 * 86400000) })
+
+    const inToday = await q(`SELECT count(*)::int AS c FROM ingest.${pname(0)} WHERE id = $1`, [recent])
+    expect(inToday.rows[0].c).toBe(1)
+    const inDefault = await q('SELECT count(*)::int AS c FROM ingest.stream_uploads_default WHERE id = $1', [ancient])
+    expect(inDefault.rows[0].c).toBe(1)
+    // both visible through the parent
+    const total = await q('SELECT count(*)::int AS c FROM ingest.stream_uploads WHERE id IN ($1,$2)', [recent, ancient])
+    expect(total.rows[0].c).toBe(2)
+  })
+
+  test('drop_expired_partitions drops strictly-older partitions, keeps the boundary and DEFAULT', async () => {
+    await q('SELECT ingest.ensure_partitions(1)')
+    await createPartitionFor(20) // clearly expired at 14d retention
+    await createPartitionFor(14) // boundary: covers [d, d+1) with d = today-14; bound_to = today-13 > today-14 -> KEPT
+    await createPartitionFor(5) // inside window
+
+    await pgTesting.insertUpload({ createdAt: new Date(Date.now() - 20 * 86400000) })
+    const keeper = await pgTesting.insertUpload({ createdAt: new Date(Date.now() - 5 * 86400000) })
+
+    const dropped = await q('SELECT ingest.drop_expired_partitions(14) AS n')
+    expect(dropped.rows[0].n).toBe(1) // only the 20-day-old one
+
+    const names = await partitionNames()
+    expect(names).not.toContain(pname(20))
+    expect(names).toContain(pname(14))
+    expect(names).toContain(pname(5))
+    expect(names).toContain('stream_uploads_default')
+
+    // the expired row went with its partition; the keeper survives
+    const res = await q('SELECT count(*)::int AS c FROM ingest.stream_uploads')
+    expect(res.rows[0].c).toBe(1)
+    const kept = await q('SELECT count(*)::int AS c FROM ingest.stream_uploads WHERE id = $1', [keeper])
+    expect(kept.rows[0].c).toBe(1)
+  })
+
+  test('drop_expired_partitions never touches the DEFAULT partition even with ancient rows in it', async () => {
+    const ancient = await pgTesting.insertUpload({ createdAt: new Date(Date.now() - 400 * 86400000) })
+    const before = await partitionNames()
+    await q('SELECT ingest.drop_expired_partitions(14)')
+    const after = await partitionNames()
+    expect(after).toContain('stream_uploads_default')
+    expect(after.length).toBe(before.length) // nothing dropped (only default + fresh horizon here)
+    const row = await q('SELECT count(*)::int AS c FROM ingest.stream_uploads WHERE id = $1', [ancient])
+    expect(row.rows[0].c).toBe(1)
+  })
+
+  test('the seam still finds uploads across partitions by id alone (PK is (id, created_at))', async () => {
+    await q('SELECT ingest.ensure_partitions(1)')
+    await createPartitionFor(5)
+    const db = require('./uploads-pg')
+    const oldId = await pgTesting.insertUpload({ createdAt: new Date(Date.now() - 5 * 86400000), streamId: 'old-day' })
+    const newId = await pgTesting.insertUpload({ createdAt: new Date(), streamId: 'new-day' })
+    expect((await db.getUpload(oldId)).streamId).toBe('old-day')
+    expect((await db.getUpload(newId)).streamId).toBe('new-day')
+  })
+})

--- a/tools/mongo2pg-backfill.js
+++ b/tools/mongo2pg-backfill.js
@@ -138,7 +138,7 @@ const UPSERT = `
      upload_source, upload_source_deleted_at, upload_source_cleanup_message,
      multipart, ingestion_result, created_at, updated_at)
   VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
-  ON CONFLICT (id) DO UPDATE SET
+  ON CONFLICT (id, created_at) DO UPDATE SET
     stream_id = excluded.stream_id,
     user_id = excluded.user_id,
     project_id = excluded.project_id,
@@ -161,8 +161,40 @@ const UPSERT = `
   -- late-delta guard: never clobber a PG row that is newer than this Mongo doc
   WHERE ingest.stream_uploads.updated_at <= excluded.updated_at`
 
+async function ensurePartitionRange (Upload, pool, filter) {
+  // Partitioned table (migration 002): rows route by created_at, and
+  // retention drops whole partitions by name. Backfilled rows carry VERBATIM
+  // historical created_at values, so their daily partitions must exist —
+  // otherwise they land in the DEFAULT partition, which retention never
+  // drops. Create one partition per day across the source data's range.
+  const bounds = await Upload.aggregate([
+    { $match: filter },
+    { $group: { _id: null, min: { $min: '$createdAt' }, max: { $max: '$createdAt' } } }
+  ])
+  if (!bounds.length || !bounds[0].min) { return }
+  const min = new Date(bounds[0].min)
+  const max = new Date(bounds[0].max)
+  let created = 0
+  for (let d = new Date(Date.UTC(min.getUTCFullYear(), min.getUTCMonth(), min.getUTCDate()));
+    d <= max; d = new Date(d.getTime() + 86400000)) {
+    const name = `stream_uploads_p${d.toISOString().slice(0, 10).replace(/-/g, '')}`
+    const from = d.toISOString().slice(0, 10)
+    const to = new Date(d.getTime() + 86400000).toISOString().slice(0, 10)
+    const res = await pool.query(`
+      SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'ingest' AND c.relname = $1`, [name])
+    if (res.rows.length === 0) {
+      await pool.query(`CREATE TABLE ingest.${name} PARTITION OF ingest.stream_uploads FOR VALUES FROM ('${from}') TO ('${to}')`)
+      created++
+    }
+  }
+  await pool.query('SELECT ingest.ensure_partitions(3)') // today + horizon
+  console.log(`[backfill] partitions ensured (created ${created} for range ${min.toISOString().slice(0, 10)}..${max.toISOString().slice(0, 10)})`)
+}
+
 async function backfill (Upload, pool) {
   const filter = SINCE ? { updatedAt: { $gte: SINCE } } : {}
+  await ensurePartitionRange(Upload, pool, filter)
   const total = await Upload.countDocuments(filter)
   console.log(`[backfill] mode=${SINCE ? 'delta since ' + SINCE.toISOString() : 'full'} docs=${total} batch=${BATCH_SIZE}`)
 

--- a/tools/mongo2pg-backfill.js
+++ b/tools/mongo2pg-backfill.js
@@ -1,0 +1,383 @@
+// ---------------------------------------------------------------------------
+// mongo2pg S2: backfill rfcx.streamuploads (MongoDB) -> ingest.stream_uploads
+// (PostgreSQL). Idempotent — safe to re-run and to resume.
+//
+// Usage (inside an ingest-service image, with the pod's normal MONGO_* and
+// UPLOADS_POSTGRES_*/POSTGRES_* env):
+//   node tools/mongo2pg-backfill.js                # full backfill, _id order
+//   node tools/mongo2pg-backfill.js --since <ISO>  # delta: docs updated since
+//   node tools/mongo2pg-backfill.js --verify-only  # gates only, no writes
+//
+// Design rules (each verified against the live collection; see rfcx-local
+// runbooks mongo2pg-S1-design-verification-2026-08-11 + the S1 re-review):
+//  * _id-ORDER upsert (ON CONFLICT (id) DO UPDATE): re-runs converge, and a
+//    crashed run resumes by just running again.
+//  * createdAt/updatedAt copied VERBATIM — never re-stamped. Retention deletes
+//    by created_at, so re-stamping would resurrect rows Mongo's TTL was about
+//    to expire (and break the S3 verification diff).
+//  * embedded segment `_id`s are STRIPPED, and the run ASSERTS none survive:
+//    live docs carry an undeclared mongoose ObjectId per segment subdocument;
+//    copying them verbatim would leave backfilled vs post-cutover rows
+//    structurally different, silently. No code reads them.
+//  * data anomalies are copied VERBATIM, not repaired (DON'T-BLINDLY-FIX
+//    applies to migrations too): status!=20 rows with streamSourceFileId,
+//    INGESTED rows without one, empty segment arrays.
+//  * Upsert SKIPS rows whose PG updated_at is NEWER than the Mongo doc's
+//    (WHERE excluded newer-or-equal guard): after the cutover flips writes to
+//    PG, a late/stale delta pass cannot clobber post-cutover PG writes.
+//  * politeness: batched (default 1000/batch) with a small sleep between
+//    batches — the Patroni replica re-joined recently; no reason to stress
+//    WAL apply with an unthrottled bulk load.
+//
+// Verification gates (run at the end of every backfill, or standalone with
+// --verify-only):
+//  G1 counts: Mongo total vs PG total (delta mode: window counts)
+//  G2 per-status histogram: must match exactly
+//  G3 row diff: N random ids (default 500) compared field-by-field after
+//     canonicalisation (dates to epoch-ms, segments stripped of _id)
+// Exit code 0 only if every gate passes.
+// ---------------------------------------------------------------------------
+
+/* eslint-disable no-console */
+require('dotenv').config()
+
+const mongoose = require('mongoose')
+const { Pool } = require('pg')
+
+const BATCH_SIZE = Number(process.env.BACKFILL_BATCH_SIZE || 1000)
+const BATCH_SLEEP_MS = Number(process.env.BACKFILL_BATCH_SLEEP_MS || 250)
+const VERIFY_SAMPLE = Number(process.env.BACKFILL_VERIFY_SAMPLE || 500)
+
+const args = process.argv.slice(2)
+const VERIFY_ONLY = args.includes('--verify-only')
+const sinceIdx = args.indexOf('--since')
+const SINCE = sinceIdx >= 0 ? new Date(args[sinceIdx + 1]) : null
+if (sinceIdx >= 0 && isNaN(SINCE.getTime())) {
+  console.error('bad --since value (want ISO date)')
+  process.exit(2)
+}
+
+function mongoUri () {
+  const protocol = process.env.MONGO_PROTOCOL || 'mongodb+srv'
+  return protocol === 'mongodb'
+    ? `mongodb://${process.env.MONGO_USERNAME}:${process.env.MONGO_PASSWORD}@${process.env.MONGO_HOSTNAME}:${process.env.MONGO_PORT || 27017}/${process.env.MONGO_DB}?retryWrites=true&w=majority&authSource=${process.env.MONGO_AUTH_SOURCE || process.env.MONGO_DB}`
+    : `mongodb+srv://${process.env.MONGO_USERNAME}:${process.env.MONGO_PASSWORD}@${process.env.MONGO_HOSTNAME}/${process.env.MONGO_DB}?retryWrites=true&w=majority`
+}
+
+function pgPool () {
+  return new Pool({
+    host: process.env.UPLOADS_POSTGRES_HOSTNAME || process.env.POSTGRES_HOSTNAME,
+    port: Number(process.env.UPLOADS_POSTGRES_PORT || process.env.POSTGRES_PORT || 5432),
+    database: process.env.UPLOADS_POSTGRES_DB || process.env.POSTGRES_DB || 'core',
+    user: process.env.UPLOADS_POSTGRES_USERNAME || process.env.POSTGRES_USERNAME,
+    password: process.env.UPLOADS_POSTGRES_PASSWORD || process.env.POSTGRES_PASSWORD,
+    max: 3,
+    connectionTimeoutMillis: 5000
+  })
+}
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+/** Strip mongoose subdocument _id from every segment; assert none survive. */
+function cleanIngestionResult (ir) {
+  if (!ir) { return { segments: [] } }
+  const out = JSON.parse(JSON.stringify(ir))
+  delete out._id
+  if (Array.isArray(out.segments)) {
+    out.segments = out.segments.map(seg => {
+      const s = { ...seg }
+      delete s._id
+      return s
+    })
+  } else {
+    out.segments = []
+  }
+  const serialised = JSON.stringify(out)
+  if (serialised.includes('"$oid"') || serialised.includes('"_id"')) {
+    throw new Error(`segment _id survived cleaning: ${serialised.slice(0, 200)}`)
+  }
+  return out
+}
+
+function docToRow (doc) {
+  const d = doc.toObject ? doc.toObject() : doc
+  return [
+    `${d._id}`,
+    d.streamId ?? null,
+    d.userId ?? null,
+    d.projectId ?? null,
+    d.status ?? 0,
+    d.laneTier ?? 'standard',
+    d.timestamp ?? null,
+    d.duration ?? null,
+    d.originalFilename ?? null,
+    d.failureMessage ?? null,
+    d.sampleRate ?? null,
+    d.targetBitrate ?? null,
+    d.checksum ?? null,
+    d.uploadSource ? JSON.stringify(stripId(d.uploadSource)) : null,
+    d.uploadSourceDeletedAt ?? null,
+    d.uploadSourceCleanupMessage ?? null,
+    d.multipart ? JSON.stringify(stripId(d.multipart)) : null,
+    JSON.stringify(cleanIngestionResult(d.ingestionResult)),
+    d.createdAt ?? new Date(0), // verbatim; epoch fallback would itself be an anomaly worth seeing
+    d.updatedAt ?? d.createdAt ?? new Date(0)
+  ]
+}
+
+function stripId (obj) {
+  const o = JSON.parse(JSON.stringify(obj))
+  delete o._id
+  return o
+}
+
+const UPSERT = `
+  INSERT INTO ingest.stream_uploads
+    (id, stream_id, user_id, project_id, status, lane_tier, "timestamp", duration,
+     original_filename, failure_message, sample_rate, target_bitrate, checksum,
+     upload_source, upload_source_deleted_at, upload_source_cleanup_message,
+     multipart, ingestion_result, created_at, updated_at)
+  VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
+  ON CONFLICT (id) DO UPDATE SET
+    stream_id = excluded.stream_id,
+    user_id = excluded.user_id,
+    project_id = excluded.project_id,
+    status = excluded.status,
+    lane_tier = excluded.lane_tier,
+    "timestamp" = excluded."timestamp",
+    duration = excluded.duration,
+    original_filename = excluded.original_filename,
+    failure_message = excluded.failure_message,
+    sample_rate = excluded.sample_rate,
+    target_bitrate = excluded.target_bitrate,
+    checksum = excluded.checksum,
+    upload_source = excluded.upload_source,
+    upload_source_deleted_at = excluded.upload_source_deleted_at,
+    upload_source_cleanup_message = excluded.upload_source_cleanup_message,
+    multipart = excluded.multipart,
+    ingestion_result = excluded.ingestion_result,
+    created_at = excluded.created_at,
+    updated_at = excluded.updated_at
+  -- late-delta guard: never clobber a PG row that is newer than this Mongo doc
+  WHERE ingest.stream_uploads.updated_at <= excluded.updated_at`
+
+async function backfill (Upload, pool) {
+  const filter = SINCE ? { updatedAt: { $gte: SINCE } } : {}
+  const total = await Upload.countDocuments(filter)
+  console.log(`[backfill] mode=${SINCE ? 'delta since ' + SINCE.toISOString() : 'full'} docs=${total} batch=${BATCH_SIZE}`)
+
+  let lastId = null
+  let done = 0
+  let upserts = 0
+  let skippedNewer = 0
+  for (;;) {
+    const q = { ...filter }
+    if (lastId) { q._id = { $gt: lastId } }
+    const docs = await Upload.find(q).sort({ _id: 1 }).limit(BATCH_SIZE).lean()
+    if (docs.length === 0) { break }
+
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      for (const doc of docs) {
+        const res = await client.query(UPSERT, docToRow(doc))
+        if (res.rowCount === 1) { upserts++ } else { skippedNewer++ }
+      }
+      await client.query('COMMIT')
+    } catch (e) {
+      await client.query('ROLLBACK')
+      throw e
+    } finally {
+      client.release()
+    }
+
+    lastId = docs[docs.length - 1]._id
+    done += docs.length
+    if (done % 10000 < BATCH_SIZE) {
+      console.log(`[backfill] ${done}/${total} (upserted ${upserts}, skipped-newer ${skippedNewer})`)
+    }
+    await sleep(BATCH_SLEEP_MS)
+  }
+  console.log(`[backfill] DONE docs=${done} upserted=${upserts} skipped-newer=${skippedNewer}`)
+  return { done, upserts, skippedNewer }
+}
+
+// --------------------------- verification gates -----------------------------
+
+function canonDate (v) {
+  if (v === null || v === undefined) { return null }
+  return new Date(v).getTime()
+}
+
+/**
+ * Recursively sort object keys. REQUIRED before any stringify-compare:
+ * PostgreSQL jsonb does not preserve key insertion order, so identical
+ * content serialises differently between the Mongo doc and the PG row.
+ * (Found on the first real G3 run: 500/500 "divergences", all key-order.)
+ */
+function sortKeys (v) {
+  if (Array.isArray(v)) { return v.map(sortKeys) }
+  if (v && typeof v === 'object' && !(v instanceof Date)) {
+    const out = {}
+    for (const k of Object.keys(v).sort()) { out[k] = sortKeys(v[k]) }
+    return out
+  }
+  return v
+}
+
+function canonDoc (d) {
+  return {
+    streamId: d.streamId ?? null,
+    userId: d.userId ?? null,
+    projectId: d.projectId ?? null,
+    status: Number(d.status ?? 0),
+    laneTier: d.laneTier ?? 'standard',
+    timestamp: canonDate(d.timestamp),
+    duration: d.duration === null || d.duration === undefined ? null : Number(d.duration),
+    originalFilename: d.originalFilename ?? null,
+    failureMessage: d.failureMessage ?? null,
+    sampleRate: d.sampleRate ?? null,
+    targetBitrate: d.targetBitrate ?? null,
+    checksum: d.checksum ?? null,
+    uploadSource: d.uploadSource ? stripId(d.uploadSource) : null,
+    uploadSourceDeletedAt: canonDate(d.uploadSourceDeletedAt),
+    uploadSourceCleanupMessage: d.uploadSourceCleanupMessage ?? null,
+    multipart: d.multipart
+      ? { ...stripId(d.multipart), completedAt: canonDate(d.multipart.completedAt), abortedAt: canonDate(d.multipart.abortedAt) }
+      : null,
+    ingestionResult: (() => {
+      const ir = cleanIngestionResult(d.ingestionResult)
+      if (ir.ingestedAt !== undefined) { ir.ingestedAt = canonDate(ir.ingestedAt) }
+      ir.segments = (ir.segments || []).map(s => ({ ...s, start: canonDate(s.start), end: canonDate(s.end) }))
+      return ir
+    })(),
+    createdAt: canonDate(d.createdAt),
+    updatedAt: canonDate(d.updatedAt)
+  }
+}
+
+function canonRow (r) {
+  const multipart = r.multipart
+    ? { ...r.multipart, completedAt: canonDate(r.multipart.completedAt), abortedAt: canonDate(r.multipart.abortedAt) }
+    : null
+  const ir = r.ingestion_result || { segments: [] }
+  if (ir.ingestedAt !== undefined) { ir.ingestedAt = canonDate(ir.ingestedAt) }
+  ir.segments = (ir.segments || []).map(s => ({ ...s, start: canonDate(s.start), end: canonDate(s.end) }))
+  return {
+    streamId: r.stream_id ?? null,
+    userId: r.user_id ?? null,
+    projectId: r.project_id ?? null,
+    status: Number(r.status ?? 0),
+    laneTier: r.lane_tier ?? 'standard',
+    timestamp: canonDate(r.timestamp),
+    duration: r.duration === null || r.duration === undefined ? null : Number(r.duration),
+    originalFilename: r.original_filename ?? null,
+    failureMessage: r.failure_message ?? null,
+    sampleRate: r.sample_rate ?? null,
+    targetBitrate: r.target_bitrate ?? null,
+    checksum: r.checksum ?? null,
+    uploadSource: r.upload_source ?? null,
+    uploadSourceDeletedAt: canonDate(r.upload_source_deleted_at),
+    uploadSourceCleanupMessage: r.upload_source_cleanup_message ?? null,
+    multipart,
+    ingestionResult: ir,
+    createdAt: canonDate(r.created_at),
+    updatedAt: canonDate(r.updated_at)
+  }
+}
+
+async function verify (Upload, pool) {
+  const filter = SINCE ? { updatedAt: { $gte: SINCE } } : {}
+  const failures = []
+
+  // G1 counts
+  const mongoTotal = await Upload.countDocuments(filter)
+  const pgTotalRes = SINCE
+    ? await pool.query('SELECT count(*)::bigint AS c FROM ingest.stream_uploads WHERE updated_at >= $1', [SINCE])
+    : await pool.query('SELECT count(*)::bigint AS c FROM ingest.stream_uploads')
+  const pgTotal = Number(pgTotalRes.rows[0].c)
+  // PG may exceed Mongo AFTER cutover (new writes) or after TTL expiry on the
+  // Mongo side; before cutover with fresh backfill they must be >=.
+  const g1 = pgTotal >= mongoTotal
+  console.log(`[verify:G1] counts mongo=${mongoTotal} pg=${pgTotal} -> ${g1 ? 'PASS' : 'FAIL'}`)
+  if (!g1) { failures.push('G1 counts') }
+
+  // G2 per-status histogram (Mongo-side statuses must all be present in PG
+  // with >= counts; exact-match pre-cutover)
+  const mongoHist = await Upload.aggregate([
+    { $match: filter },
+    { $group: { _id: '$status', n: { $sum: 1 } } }
+  ])
+  const pgHist = SINCE
+    ? await pool.query('SELECT status, count(*)::bigint AS n FROM ingest.stream_uploads WHERE updated_at >= $1 GROUP BY status', [SINCE])
+    : await pool.query('SELECT status, count(*)::bigint AS n FROM ingest.stream_uploads GROUP BY status')
+  const pgByStatus = Object.fromEntries(pgHist.rows.map(r => [Number(r.status), Number(r.n)]))
+  let g2 = true
+  for (const { _id: status, n } of mongoHist) {
+    const pgN = pgByStatus[Number(status)] || 0
+    const ok = pgN >= n
+    console.log(`[verify:G2] status=${status} mongo=${n} pg=${pgN} -> ${ok ? 'ok' : 'MISSING'}`)
+    if (!ok) { g2 = false }
+  }
+  console.log(`[verify:G2] histogram -> ${g2 ? 'PASS' : 'FAIL'}`)
+  if (!g2) { failures.push('G2 histogram') }
+
+  // G3 random row diff
+  const sample = await Upload.aggregate([{ $match: filter }, { $sample: { size: VERIFY_SAMPLE } }])
+  let diffs = 0
+  for (const doc of sample) {
+    const rowRes = await pool.query('SELECT * FROM ingest.stream_uploads WHERE id = $1', [`${doc._id}`])
+    if (rowRes.rows.length === 0) {
+      diffs++
+      if (diffs <= 3) { console.log(`[verify:G3] MISSING in PG: ${doc._id}`) }
+      continue
+    }
+    const a = JSON.stringify(sortKeys(canonDoc(doc)))
+    const b = JSON.stringify(sortKeys(canonRow(rowRes.rows[0])))
+    if (a !== b) {
+      diffs++
+      if (diffs <= 3) {
+        console.log(`[verify:G3] DIVERGED ${doc._id}`)
+        console.log(`  mongo: ${a.slice(0, 300)}`)
+        console.log(`  pg   : ${b.slice(0, 300)}`)
+      }
+    }
+  }
+  const g3 = diffs === 0
+  console.log(`[verify:G3] sampled=${sample.length} diffs=${diffs} -> ${g3 ? 'PASS' : 'FAIL'}`)
+  if (!g3) { failures.push('G3 row diff') }
+
+  return failures
+}
+
+// ------------------------------------ main ----------------------------------
+
+async function main () {
+  console.log('[backfill] connecting mongo + pg')
+  mongoose.set('strictQuery', false)
+  await mongoose.connect(mongoUri())
+  const Upload = require('../services/db/models/mongoose/upload').Upload
+  const pool = pgPool()
+  await pool.query('SELECT 1') // fail fast on bad PG config
+
+  try {
+    if (!VERIFY_ONLY) {
+      await backfill(Upload, pool)
+    }
+    const failures = await verify(Upload, pool)
+    if (failures.length) {
+      console.error(`[backfill] VERIFICATION FAILED: ${failures.join(', ')}`)
+      process.exitCode = 1
+    } else {
+      console.log('[backfill] ALL GATES PASS')
+    }
+  } finally {
+    await pool.end()
+    await mongoose.disconnect()
+  }
+}
+
+main().catch((e) => {
+  console.error('[backfill] FATAL', e && e.stack ? e.stack : e)
+  process.exit(1)
+})

--- a/tools/mongo2pg-backfill.js
+++ b/tools/mongo2pg-backfill.js
@@ -174,22 +174,15 @@ async function ensurePartitionRange (Upload, pool, filter) {
   if (!bounds.length || !bounds[0].min) { return }
   const min = new Date(bounds[0].min)
   const max = new Date(bounds[0].max)
-  let created = 0
-  for (let d = new Date(Date.UTC(min.getUTCFullYear(), min.getUTCMonth(), min.getUTCDate()));
-    d <= max; d = new Date(d.getTime() + 86400000)) {
-    const name = `stream_uploads_p${d.toISOString().slice(0, 10).replace(/-/g, '')}`
-    const from = d.toISOString().slice(0, 10)
-    const to = new Date(d.getTime() + 86400000).toISOString().slice(0, 10)
-    const res = await pool.query(`
-      SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE n.nspname = 'ingest' AND c.relname = $1`, [name])
-    if (res.rows.length === 0) {
-      await pool.query(`CREATE TABLE ingest.${name} PARTITION OF ingest.stream_uploads FOR VALUES FROM ('${from}') TO ('${to}')`)
-      created++
-    }
-  }
+  // Partition creation is DDL, which the app role is (correctly) DENIED —
+  // it goes through the SECURITY DEFINER maintenance functions instead.
+  // (v1 of this tool did raw CREATE TABLE and the privilege model rejected
+  // it in production: the deny was the system working as designed.)
+  const fromDay = min.toISOString().slice(0, 10)
+  const toDay = max.toISOString().slice(0, 10)
+  const created = await pool.query('SELECT ingest.ensure_partitions_range($1::date, $2::date) AS n', [fromDay, toDay])
   await pool.query('SELECT ingest.ensure_partitions(3)') // today + horizon
-  console.log(`[backfill] partitions ensured (created ${created} for range ${min.toISOString().slice(0, 10)}..${max.toISOString().slice(0, 10)})`)
+  console.log(`[backfill] partitions ensured (created ${created.rows[0].n} for range ${fromDay}..${toDay})`)
 }
 
 async function backfill (Upload, pool) {

--- a/utils/testing/pg.js
+++ b/utils/testing/pg.js
@@ -5,9 +5,9 @@
 // behaviour, partial indexes, char(24) comparison semantics and ON CONFLICT,
 // none of which an in-memory stub would reproduce faithfully.
 //
-// It applies THE SAME `migrations/pg/001-ingest-schema.sql` that S2 applies to
-// the cluster, VERBATIM, so the tested schema and the deployed schema cannot
-// drift.
+// It applies THE SAME `migrations/pg/002-ingest-schema-partitioned.sql` that
+// the platform applies to the cluster, VERBATIM, so the tested schema and the
+// deployed schema cannot drift.
 //
 // PARALLELISM: jest runs suites in parallel workers against one server, so each
 // worker gets its OWN DATABASE (`<base>_w<JEST_WORKER_ID>`) containing the real

--- a/utils/testing/pg.js
+++ b/utils/testing/pg.js
@@ -28,7 +28,8 @@ const fs = require('fs')
 const path = require('path')
 const { Pool } = require('pg')
 
-const MIGRATION_PATH = path.join(__dirname, '..', '..', 'migrations', 'pg', '001-ingest-schema.sql')
+// 002 (partitioned) superseded 001 before any traffic reached the table.
+const MIGRATION_PATH = path.join(__dirname, '..', '..', 'migrations', 'pg', '002-ingest-schema-partitioned.sql')
 
 const WORKER_ID = process.env.JEST_WORKER_ID || `p${process.pid}`
 
@@ -114,6 +115,8 @@ async function migrate () {
 async function connect () {
   await createWorkerDatabase()
   await migrate()
+  // exercise the partition-maintenance path the retention job will use
+  await getPool().query('SELECT ingest.ensure_partitions(3)')
   // Point the module under test at this worker's database.
   process.env.UPLOADS_POSTGRES_DB = workerDbName()
 }


### PR DESCRIPTION
Backfill `rfcx.streamuploads` → `ingest.stream_uploads` for the mongo2pg migration (rfcx-local OPEN-ITEMS #67, follows #113).

- Idempotent `_id`-order upsert; resumable; `--since` delta mode; `--verify-only`.
- createdAt/updatedAt verbatim; segment `_id`s stripped + asserted absent; anomalies copied, not repaired.
- Late-delta guard: won't overwrite PG rows newer than the Mongo doc (protects post-cutover writes).
- 3 verification gates (counts / status histogram / 500-random-row canonical diff). Comparator recursively sorts keys — jsonb doesn't preserve key order; the first real run's 500/500 'divergences' were all key-order, the uniform-failure tooling signature.
- Verified against production data (48h window, 4,988 docs): all gates pass.

Tool only — nothing imports it; no runtime behaviour change.