### PR TITLE
fix: upload-status log says 'Mongo' but the store is now PG — neutral wording

### DIFF
--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -254,7 +254,7 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
     tracker.logAndSetNewPoint(`[${uploadId}] downloaded file`)
     console.info(`[${uploadId}] Updating upload status to UPLOADED`)
     await db.updateUploadStatus(uploadId, db.status.UPLOADED)
-    tracker.logAndSetNewPoint(`[${uploadId}] updated upload status in Mongo`)
+    tracker.logAndSetNewPoint(`[${uploadId}] updated upload status in upload store`)
 
     const fileData = await audioService.identify(fileLocalPath)
     tracker.logAndSetNewPoint(`[${uploadId}] identified file with ffmpeg`)
@@ -325,7 +325,7 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
 
     console.info(`[${uploadId}] Modifying status to INGESTED (${db.status.INGESTED})`)
     await db.updateUploadStatus(uploadId, db.status.INGESTED, null, buildIngestionResult(coreData, outputFiles, upload))
-    tracker.logAndSetNewPoint(`[${uploadId}] updated upload status in Mongo`)
+    tracker.logAndSetNewPoint(`[${uploadId}] updated upload status in upload store`)
 
     if (PROMETHEUS_ENABLED && fileData.sampleCount) {
       console.info(`[${uploadId}] Updating processing metrics`)


### PR DESCRIPTION
**What:** two log literals in `services/rfcx/ingest.js` — `updated upload status in Mongo` → `updated upload status in upload store`. No behaviour change.

**Why:** since the mongo2pg S3 cutover (2026-08-11, `UPLOADS_DB=pg`), these lines log a Mongo write that is actually a PostgreSQL write via the `services/db/uploads.js` seam. During post-cutover live verification (2026-08-12) an error/mongo log grep matched 126 of these lines and briefly suggested residual Mongo traffic; Mongo had zero new documents — the wording was the artefact. Backend-neutral phrasing keeps the log truthful under either engine.

**Verification:** `node --check` clean; no test asserts the old string; grep confirms no other live-path 'in Mongo' literals remain (remaining mentions are the seam's accurate comments).

Base: `ba6721e` (master tip). Part of OPEN-ITEMS #67 soak-window cleanup; S4 retirement will remove the mongo path entirely.