### PR TITLE
feat(uploads): allow historical recordings; reject unset recorder clocks by provenance

### DIFF
--- a/routes/uploads.int.test.js
+++ b/routes/uploads.int.test.js
@@ -117,10 +117,29 @@ describe('POST /uploads', () => {
     expect(response.statusCode).toBe(400)
     expect(response.body.message).toEqual(`Future date upload: ${requestBody.timestamp}`)
   })
-  test('returns validation error if timestamp is past older than year 1971', async () => {
+  test('ACCEPTS a historical (pre-1971) timestamp — digitised archive material', async () => {
+    // Behaviour change 2026-08-13: pre-1971 dates are no longer blanket-
+    // rejected. Digitised tape/archive recordings are legitimate and the
+    // storage layer represents them natively. The "a digital recorder cannot
+    // predate 1971" rule needs the file's own metadata, which does not exist
+    // at sign time, so it is enforced at ingest instead
+    // (services/rfcx/ingest.js -> validateAudioMeta).
+    const requestBody = {
+      filename: 'archive-1955-06-12T10-15-00.flac',
+      timestamp: moment('1955-06-12T10:15:00.000Z').utc(),
+      stream: '0a1824085e3f',
+      checksum: 'acd44fdcc42e0dad141f35ae1aa029fd6b3f9eca',
+      sampleRate: 64000,
+      targetBitrate: 1
+    }
+    const response = await request(app).post('/uploads').send(requestBody)
+    expect(response.statusCode).toBe(200)
+  })
+
+  test('returns validation error if timestamp is absurdly old (parse failure)', async () => {
     const requestBody = {
       filename: '0a1824085e3f-2021-06-08T19-26-40.flac',
-      timestamp: moment('1970-12-31T23:59:59.999Z').utc() /* past */,
+      timestamp: moment('0218-03-21T05:10:00.000Z').utc() /* misparsed */,
       stream: '0a1824085e3f',
       checksum: 'acd44fdcc42e0dad141f35ae1aa029fd6b3f9eca',
       sampleRate: 64000,
@@ -128,7 +147,7 @@ describe('POST /uploads', () => {
     }
     const response = await request(app).post('/uploads').send(requestBody)
     expect(response.statusCode).toBe(400)
-    expect(response.body.message).toEqual(`Past date upload: ${requestBody.timestamp}`)
+    expect(response.body.message).toMatch(/not a plausible recording date/)
   })
   test('returns validation error if duration is more than 24 hours', async () => {
     const requestBody = {

--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -12,6 +12,7 @@ const auth0Service = require('../services/auth0')
 const moment = require('moment-timezone')
 const { getSampleRateFromFilename } = require('../services/rfcx/guardian')
 const { maxDurationWithGraceSeconds, maxDurationHoursDisplay, flacLimitSize, wavLimitSize, otherLimitSize } = require('../utils/limits')
+const { minRecordingYear } = require('../utils/recorder-provenance')
 
 const maxBulkUploadCount = Number(process.env.UPLOAD_BULK_MAX_ITEMS || 100)
 
@@ -74,10 +75,19 @@ async function validateUploadParams (params) {
     throw new ValidationError(`Future date upload: ${params.timestamp}`)
   }
 
-  // Cannot upload to the past older than year 1971
-  const isPast = params.timestamp.year() < 1971
-  if (isPast) {
-    throw new ValidationError(`Past date upload: ${params.timestamp}`)
+  // Historical recordings ARE permitted (digitised tape/archive material):
+  // the storage layer represents them natively and production already holds
+  // ~551 genuine pre-1971 segments. What must still be rejected is an UNSET
+  // RECORDER CLOCK (a dead battery restarts a digital recorder at the Unix
+  // epoch), and that is decided by PROVENANCE, not by the date alone.
+  //
+  // At sign time we have no file bytes and therefore no recorder tags, so we
+  // can only enforce the absurdity floor here. The provenance rule runs at
+  // ingest, where ffprobe has read the file's own metadata
+  // (services/rfcx/ingest.js -> validateAudioMeta). See
+  // utils/recorder-provenance.js for the measurements behind this.
+  if (params.timestamp.year() < minRecordingYear) {
+    throw new ValidationError(`Past date upload: ${params.timestamp} (before ${minRecordingYear}, which is not a plausible recording date)`)
   }
 
   // Cannot upload file that duration more than the configured max (milliseconds)

--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -21,6 +21,7 @@ const losslessExtensions = ['.wav', '.flac']
 const extensionsRequiringConvToWav = ['.flac']
 
 const { IngestionError } = require('../../utils/errors')
+const { checkRecordingTimestamp } = require('../../utils/recorder-provenance')
 const { maxDurationWithGraceSeconds, maxDurationHoursDisplay } = require('../../utils/limits')
 const loggerIgnoredErrors = [
   /Duplicate file\. Matching sha1 signature already ingested\./,
@@ -84,6 +85,15 @@ function validateFileFormat (extension) {
  * @param {*} extension
  */
 function validateAudioMeta (upload, meta, extension) {
+  // Provenance-aware date check. This is the ONLY point in the pipeline where
+  // the file's own metadata is available (ffprobe format.tags), so it is where
+  // the "a digital recorder cannot predate 1971" rule can actually be applied.
+  // The upload API can only enforce the absurdity floor (no bytes yet).
+  // Genuine digitised archives carry no recorder tags and pass freely.
+  const timestampProblem = checkRecordingTimestamp(upload.timestamp, meta.tags)
+  if (timestampProblem !== null) {
+    throw new IngestionError(timestampProblem)
+  }
   if (isNaN(meta.duration) || meta.duration === 0) {
     throw new IngestionError('Audio duration is zero')
   }

--- a/utils/recorder-provenance.js
+++ b/utils/recorder-provenance.js
@@ -1,0 +1,213 @@
+/**
+ * Recorder-provenance validation for historical (pre-epoch) recordings.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `routes/uploads.js` used to reject ANY timestamp before 1971. That blanket
+ * rule conflated two very different things:
+ *
+ *   1. GENUINE historical material — digitised tape/archive recordings whose
+ *      real date is 1955, 1941, 1900... These are legitimate and Arbimon's
+ *      storage supports them (stream_segments.start is timestamptz; the
+ *      TimescaleDB hypertable already holds 213 pre-epoch chunks).
+ *
+ *   2. UNSET RECORDER CLOCKS — a digital recorder whose battery died and whose
+ *      clock restarted at the Unix epoch, producing a burst of files stamped
+ *      1970-01-01 onwards. These are WRONG, and silently so.
+ *
+ * The operator's rule separates them by PROVENANCE rather than by date:
+ * digital field recorders (AudioMoth, Song Meter, ...) did not exist before
+ * 1971, so a file whose own metadata names one CANNOT genuinely predate that
+ * date. A digitised archive recording, by contrast, carries no such metadata.
+ *
+ * MEASURED ON PRODUCTION (2026-08-13, core.stream_segments, 229,024 pre-1971
+ * segments across 287 streams) — the rule separates the classes cleanly:
+ *
+ *   bucket                                segments   with recorder metadata
+ *   epoch-drift window (12-31 .. 01-14)    220,985            59.0%
+ *   rest of 1970                             7,321            95.7%
+ *   plausible historical (1900..1969-11)       551             0.4%
+ *   absurd (< 1900)                            167             0.0%
+ *
+ * Control: of 302,303 files ingested in the previous 30 days, 273,774 (90.6%)
+ * carry recorder metadata — so its ABSENCE is meaningful, not just missing.
+ *
+ * The two apparent counter-examples were themselves misparsed files, and they
+ * strengthen the rule: parsed start 1901-02-16, but the AudioMoth comment says
+ * "Recorded at 06:00:00 17/02/2019" (filename `160219010101.WAV` — a DDMMYY
+ * name read as YYMMDD). The rule rejects them, correctly, and the metadata
+ * even supplies the true date.
+ *
+ * WHY NOT A DATE-WINDOW GUARD (an earlier proposal, discarded by evidence):
+ * blocking 1969-12-31..1970-01-14 outright would destroy genuine archival
+ * uploads. Real xeno-canto material sits INSIDE that window with placeholder
+ * dates, e.g. `ChestnutRumpedBabblerXC360083dt19700101_000000.wav`
+ * ("album":"xeno-canto", attributed recordists). Provenance keeps those; a
+ * date window would not.
+ */
+
+/**
+ * Signatures of digital field recorders. Matched case-insensitively against
+ * the file's own container tags (ffprobe `format.tags`).
+ *
+ * Keep this list CONSERVATIVE: a false positive rejects a legitimate archive
+ * upload. Every entry here is a device/format that demonstrably postdates
+ * 1971 and appears in production metadata.
+ */
+const RECORDER_SIGNATURES = [
+  { pattern: /AudioMoth/i, name: 'AudioMoth' },
+  { pattern: /GUANO/, name: 'GUANO metadata (bioacoustic recorder)' },
+  { pattern: /Song\s?Meter/i, name: 'Song Meter' },
+  { pattern: /Wildlife\s?Acoustics/i, name: 'Wildlife Acoustics' },
+  { pattern: /SongMeter/i, name: 'Song Meter' },
+  { pattern: /Swift\s?Recorder/i, name: 'Swift' },
+  { pattern: /Avisoft/i, name: 'Avisoft-RECORDER' },
+  { pattern: /Zoom\s+H[1-9]/i, name: 'Zoom handheld recorder' }
+]
+
+/**
+ * The earliest plausible recording date. Sound recording begins ~1860
+ * (phonautogram) and practical field recording much later; anything before
+ * this is a parse failure, not a recording. Production holds 167 such rows
+ * (year 0218, 0306, 1501, ...), all from misparsed filenames.
+ *
+ * Env-overridable so it can be tuned without a rebuild.
+ */
+function intFromEnv (name, fallback) {
+  const raw = process.env[name]
+  if (raw === undefined || raw === null || raw === '') { return fallback }
+  const n = parseInt(raw, 10)
+  return Number.isFinite(n) ? n : fallback
+}
+
+const minRecordingYear = intFromEnv('MIN_RECORDING_YEAR', 1800)
+
+/**
+ * The year before which a DIGITAL RECORDER could not have produced audio.
+ * Deliberately the same 1971 boundary the old blanket rule used, so behaviour
+ * for recorder-tagged files is UNCHANGED; only untagged (archival) files gain
+ * new freedom.
+ */
+const minDigitalRecorderYear = intFromEnv('MIN_DIGITAL_RECORDER_YEAR', 1971)
+
+/**
+ * Maximum tolerated disagreement (in days) between a timestamp and a date
+ * embedded in the file's own metadata. Production shows misparsed filenames
+ * off by ~110 years (parsed 1901-12-09 vs embedded "date":"2012-11-19"),
+ * while legitimate timezone/rounding differences are hours at most.
+ */
+const maxMetadataDateDriftDays = intFromEnv('MAX_METADATA_DATE_DRIFT_DAYS', 366)
+
+/**
+ * Flatten ffprobe format tags to one searchable string.
+ * Tags look like: { comment: 'Recorded at ... by AudioMoth ...',
+ *                   artist: 'AudioMoth 248D...', encoder: 'Lavf61.7.100' }
+ * @param {object} tags
+ * @returns {string}
+ */
+function flattenTags (tags) {
+  if (tags === null || tags === undefined || typeof tags !== 'object') { return '' }
+  return Object.values(tags)
+    .filter(v => typeof v === 'string' || typeof v === 'number')
+    .join(' ; ')
+}
+
+/**
+ * Identify the digital recorder named by a file's metadata, if any.
+ * @param {object} tags ffprobe format.tags
+ * @returns {string|null} recorder display name, or null when none is named
+ */
+function detectRecorder (tags) {
+  const haystack = flattenTags(tags)
+  if (haystack === '') { return null }
+  for (const sig of RECORDER_SIGNATURES) {
+    if (sig.pattern.test(haystack)) { return sig.name }
+  }
+  return null
+}
+
+/**
+ * Extract a date embedded in the file's own metadata, when the container
+ * carries one independent of the filename.
+ *
+ * Two shapes seen in production:
+ *   - BWF/Avisoft: tags.date = "2012-11-19"
+ *   - AudioMoth ICMT: "Recorded at HH:MM:SS DD/MM/YYYY (UTC...) by AudioMoth"
+ *
+ * @param {object} tags
+ * @returns {Date|null} UTC date (day precision is sufficient here)
+ */
+function extractMetadataDate (tags) {
+  const haystack = flattenTags(tags)
+  if (haystack === '') { return null }
+
+  // AudioMoth comment: DD/MM/YYYY
+  const am = haystack.match(/Recorded at \d{2}:\d{2}:\d{2}(?:\.\d+)? (\d{2})\/(\d{2})\/(\d{4})/)
+  if (am !== null) {
+    const [, d, mo, y] = am
+    const parsed = new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d)))
+    if (!isNaN(parsed.getTime())) { return parsed }
+  }
+
+  // BWF-style ISO date tag (Avisoft and friends): YYYY-MM-DD
+  const iso = haystack.match(/(?:^|[^0-9])((?:19|20)\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])(?:[^0-9]|$)/)
+  if (iso !== null) {
+    const [, y, mo, d] = iso
+    const parsed = new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d)))
+    if (!isNaN(parsed.getTime())) { return parsed }
+  }
+
+  return null
+}
+
+/**
+ * Provenance-aware validation of a recording timestamp.
+ *
+ * Replaces the old blanket "reject anything before 1971" rule. Returns a
+ * rejection reason string, or null when the timestamp is acceptable.
+ *
+ * @param {Date|object} timestamp recording start (Date or moment)
+ * @param {object} tags ffprobe format.tags for the file (may be empty)
+ * @returns {string|null} human-readable rejection reason, or null if OK
+ */
+function checkRecordingTimestamp (timestamp, tags) {
+  const date = (timestamp instanceof Date) ? timestamp : new Date(timestamp.valueOf())
+  if (isNaN(date.getTime())) { return 'Recording timestamp is not a valid date' }
+
+  const year = date.getUTCFullYear()
+
+  // 1. Absurdity floor — a parse failure, not a recording.
+  if (year < minRecordingYear) {
+    return `Recording date ${date.toISOString().slice(0, 10)} is before ${minRecordingYear}, which is not a plausible recording date (the filename or timestamp format is probably being misread)`
+  }
+
+  // 2. Provenance rule: a digital recorder cannot predate its own existence.
+  if (year < minDigitalRecorderYear) {
+    const recorder = detectRecorder(tags)
+    if (recorder !== null) {
+      return `This file's metadata says it was recorded by ${recorder}, which cannot predate ${minDigitalRecorderYear} — the recorder's clock was most likely unset (a dead battery restarts it at 1970-01-01). Correct the date, or re-upload after fixing the recorder clock.`
+    }
+  }
+
+  // 3. Metadata contradiction: the file's own embedded date disagrees wildly.
+  //    Catches misparsed filenames regardless of recorder brand.
+  const metaDate = extractMetadataDate(tags)
+  if (metaDate !== null) {
+    const driftDays = Math.abs(date.getTime() - metaDate.getTime()) / 86400000
+    if (driftDays > maxMetadataDateDriftDays) {
+      return `The recording date ${date.toISOString().slice(0, 10)} disagrees with the date stored inside the file (${metaDate.toISOString().slice(0, 10)}) by ${Math.round(driftDays / 365.25)} years — the filename timestamp format is probably being misread`
+    }
+  }
+
+  return null
+}
+
+module.exports = {
+  checkRecordingTimestamp,
+  detectRecorder,
+  extractMetadataDate,
+  minRecordingYear,
+  minDigitalRecorderYear,
+  maxMetadataDateDriftDays,
+  RECORDER_SIGNATURES
+}

--- a/utils/recorder-provenance.test.js
+++ b/utils/recorder-provenance.test.js
@@ -1,0 +1,181 @@
+const {
+  checkRecordingTimestamp,
+  detectRecorder,
+  extractMetadataDate
+} = require('./recorder-provenance')
+
+/**
+ * Provenance-aware historical-date validation.
+ *
+ * The behaviours that matter are asymmetric, so they are tested separately:
+ *  - a GENUINE digitised archive (no recorder tags) must be ACCEPTED, however
+ *    old it is. This is the capability being added.
+ *  - a digital recorder claiming a pre-1971 date must be REJECTED. This is the
+ *    unset-clock class the old blanket rule existed to catch.
+ * Both directions are load-bearing: relaxing one without the other either
+ * blocks real archives or lets silently-wrong data in.
+ *
+ * The fixtures below are REAL metadata shapes taken from production
+ * (core.stream_source_files.meta), not invented ones.
+ */
+
+const AUDIOMOTH_TAGS = {
+  comment: 'Recorded at 19:30:00 09/08/2025 (UTC-5) by AudioMoth 248D9B04645707D7 at medium gain while battery was 4.5V and temperature was 12.3C.',
+  artist: 'AudioMoth 248D9B04645707D7',
+  encoder: 'Lavf61.7.100'
+}
+
+const GUANO_TAGS = {
+  comment: 'GUANO|Version:1.0;Firmware Version:4.7;Make:Wildlife Acoustics, Inc.;Model:Song Meter Micro;Serial:2MM18874;WA|Song Meter|Prefix:2MM18874;WA|Song Meter|Audio settings:rate:24000,gain:18;Length:60.000'
+}
+
+const XENO_CANTO_TAGS = {
+  title: 'Chestnut-rumped Babbler (Stachyris maculata)',
+  album: 'xeno-canto',
+  artist: 'Peter Boesman',
+  comment: 'XC360083 C Peter Boesman'
+}
+
+const ENCODER_ONLY_TAGS = { encoder: 'Lavf58.24.101' }
+
+const AVISOFT_TAGS = {
+  encoded_by: 'Avisoft-RECORDER',
+  date: '2012-12-05',
+  time_reference: '46332746928'
+}
+
+const utc = (iso) => new Date(iso)
+
+describe('recorder provenance: historical dates', () => {
+  describe('ACCEPTS genuine archival material', () => {
+    test('1955 field recording with no recorder metadata', () => {
+      expect(checkRecordingTimestamp(utc('1955-06-12T10:15:00Z'), {})).toBeNull()
+    })
+
+    test('1941 recording with only an encoder tag (transcoded archive)', () => {
+      expect(checkRecordingTimestamp(utc('1941-01-01T01:01:01Z'), ENCODER_ONLY_TAGS)).toBeNull()
+    })
+
+    test('1900 digitised archive', () => {
+      expect(checkRecordingTimestamp(utc('1900-01-01T01:01:01Z'), {})).toBeNull()
+    })
+
+    test('xeno-canto archival upload INSIDE the epoch-drift window', () => {
+      // Real production row: placeholder date, legitimate attributed recording.
+      // A naive date-window guard would have destroyed this.
+      expect(checkRecordingTimestamp(utc('1969-12-31T17:00:00Z'), XENO_CANTO_TAGS)).toBeNull()
+      expect(checkRecordingTimestamp(utc('1970-01-13T09:00:00Z'), XENO_CANTO_TAGS)).toBeNull()
+    })
+
+    test('null/absent tags do not throw', () => {
+      expect(checkRecordingTimestamp(utc('1960-05-05T00:00:00Z'), null)).toBeNull()
+      expect(checkRecordingTimestamp(utc('1960-05-05T00:00:00Z'), undefined)).toBeNull()
+    })
+  })
+
+  describe('REJECTS impossible digital-recorder dates', () => {
+    test('AudioMoth claiming 1970 (unset clock)', () => {
+      const reason = checkRecordingTimestamp(utc('1970-01-01T00:00:00Z'), AUDIOMOTH_TAGS)
+      expect(reason).toMatch(/AudioMoth/)
+      expect(reason).toMatch(/clock/)
+    })
+
+    test('Song Meter / GUANO claiming 1970', () => {
+      const reason = checkRecordingTimestamp(utc('1970-01-05T12:00:00Z'), GUANO_TAGS)
+      expect(reason).not.toBeNull()
+      expect(reason).toMatch(/cannot predate/)
+    })
+
+    test('the real misparsed AudioMoth file from production', () => {
+      // parsed start 1901-02-16, but the comment says 17/02/2019.
+      // Filename was 160219010101.WAV — DDMMYY read as YYMMDD.
+      const reason = checkRecordingTimestamp(utc('1901-02-16T01:02:00Z'), {
+        comment: 'Recorded at 06:00:00 17/02/2019 (UTC) by AudioMoth 0FE081F80FE081F0 at gain setting 4 while battery state was 4.7V',
+        encoder: 'Lavf58.24.101'
+      })
+      expect(reason).not.toBeNull()
+    })
+  })
+
+  describe('REJECTS absurd dates regardless of provenance', () => {
+    test.each([
+      ['0218-03-21T05:10:00Z'],
+      ['0616-01-01T00:00:00Z'],
+      ['1501-02-03T00:00:00Z']
+    ])('%s is a parse failure', (iso) => {
+      const reason = checkRecordingTimestamp(utc(iso), {})
+      expect(reason).toMatch(/not a plausible recording date/)
+    })
+
+    test('an invalid date is reported, not silently accepted', () => {
+      expect(checkRecordingTimestamp(new Date('nonsense'), {})).toMatch(/not a valid date/)
+    })
+  })
+
+  describe('REJECTS metadata contradiction (brand-independent)', () => {
+    test('Avisoft: parsed 1901 vs embedded 2012 is rejected (by provenance, first)', () => {
+      // Avisoft IS a known digital recorder, so rule 2 fires before rule 3.
+      // Either rejection is correct; assert only that it is rejected and that
+      // the reason is actionable. (Asserting the contradiction wording here
+      // was a TEST bug: it presumed an ordering the code does not promise.)
+      const reason = checkRecordingTimestamp(utc('1901-12-09T09:28:05Z'), AVISOFT_TAGS)
+      expect(reason).not.toBeNull()
+      expect(reason).toMatch(/cannot predate|disagrees with the date stored inside the file/)
+    })
+
+    test('contradiction is caught for an UNKNOWN recorder brand too', () => {
+      // The point of rule 3: catch misparsed filenames even when no known
+      // recorder is named, so the guard is not limited to our brand list.
+      const reason = checkRecordingTimestamp(utc('1985-11-19T00:00:00Z'), {
+        encoded_by: 'SomeUnlistedDevice',
+        date: '2012-11-19'
+      })
+      expect(reason).toMatch(/disagrees with the date stored inside the file/)
+    })
+
+    test('a timezone-sized difference is NOT a contradiction', () => {
+      // same day, different zone rendering — must not trip the guard
+      expect(checkRecordingTimestamp(utc('2012-12-05T23:00:00Z'), AVISOFT_TAGS)).toBeNull()
+      expect(checkRecordingTimestamp(utc('2012-12-04T01:00:00Z'), AVISOFT_TAGS)).toBeNull()
+    })
+  })
+
+  describe('modern recordings are unaffected', () => {
+    test.each([
+      ['2025-08-09T19:30:00Z', AUDIOMOTH_TAGS],
+      ['2024-01-15T14:30:00Z', GUANO_TAGS],
+      ['1990-06-01T00:00:00Z', {}]
+    ])('%s is accepted', (iso, tags) => {
+      expect(checkRecordingTimestamp(utc(iso), tags)).toBeNull()
+    })
+
+    test('the 1971 boundary itself is accepted for a recorder-tagged file', () => {
+      // NOTE: the tags must AGREE with the timestamp, or rule 3 correctly
+      // rejects it. Pairing a 1971 date with a 2025 AudioMoth comment was a
+      // self-contradictory fixture (a TEST bug, caught here) — the code was
+      // right to reject it.
+      const tags = {
+        comment: 'Recorded at 00:00:00 01/01/1971 (UTC) by AudioMoth 248D9B04645707D7 at medium gain',
+        artist: 'AudioMoth 248D9B04645707D7'
+      }
+      expect(checkRecordingTimestamp(utc('1971-01-01T00:00:00Z'), tags)).toBeNull()
+    })
+  })
+
+  describe('helpers', () => {
+    test('detectRecorder identifies the real production shapes', () => {
+      expect(detectRecorder(AUDIOMOTH_TAGS)).toMatch(/AudioMoth/)
+      expect(detectRecorder(GUANO_TAGS)).not.toBeNull()
+      expect(detectRecorder(AVISOFT_TAGS)).toMatch(/Avisoft/)
+      expect(detectRecorder(XENO_CANTO_TAGS)).toBeNull()
+      expect(detectRecorder(ENCODER_ONLY_TAGS)).toBeNull()
+      expect(detectRecorder({})).toBeNull()
+    })
+
+    test('extractMetadataDate reads both real shapes', () => {
+      expect(extractMetadataDate(AUDIOMOTH_TAGS).toISOString().slice(0, 10)).toBe('2025-08-09')
+      expect(extractMetadataDate(AVISOFT_TAGS).toISOString().slice(0, 10)).toBe('2012-12-05')
+      expect(extractMetadataDate({})).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
Replaces the blanket **"reject any timestamp before 1971"** rule, which conflated two very different things:

1. **Genuine historical material** — digitised tape/archive recordings dated 1955, 1941, 1900… These are legitimate, and this stack *already supports them*: `stream_segments.start` is `timestamptz`, and the TimescaleDB hypertable currently holds **213 pre-epoch chunks**.
2. **Unset recorder clocks** — a flat battery restarts a digital recorder at the Unix epoch, producing a burst of files stamped 1970-01-01 onwards. Silently wrong.

The new rule separates them by **provenance, not date**: digital field recorders did not exist before 1971, so a file whose *own metadata* names one cannot genuinely predate it. A digitised archive carries no such metadata.

### Measured on production (229,024 pre-1971 segments, 287 streams)

| bucket | segments | with recorder metadata |
|---|---|---|
| epoch-drift window (12-31 … 01-14) | 220,985 | **59.0%** |
| rest of 1970 | 7,321 | **95.7%** |
| plausible historical (1900…1969-11) | 551 | **0.4%** |
| absurd (< 1900) | 167 | **0.0%** |

Control: of 302,303 files ingested in the last 30 days, **273,774 (90.6%)** carry recorder metadata — so its *absence* is meaningful. The 1970 mass also shows a textbook unset-clock decay (41,882 on Jan 1 → 33,514 on Jan 2 → tapering), and 54,937 are hex-named AudioMoth-legacy files counting from epoch zero.

### Where each check runs — the load-bearing design decision

The sign request carries **no file bytes**, so `routes/uploads.js` cannot see recorder tags; it can only enforce the absurdity floor. The provenance rule therefore runs in `services/rfcx/ingest.js` → `validateAudioMeta()`, the one point where ffprobe has already read `format.tags`.

This mirrors the desktop uploader, which never sent metadata to the sign endpoint either — it re-embedded metadata into the file and let the server read it back.

### Why not a date-window guard (an earlier proposal, discarded by evidence)

Blocking `1969-12-31 … 1970-01-14` outright would **destroy genuine archival uploads**. Real xeno-canto recordings sit *inside* that window with placeholder dates and attributed recordists, e.g. `ChestnutRumpedBabblerXC360083dt19700101_000000.wav`. Provenance keeps those; a date window would not.

### Behaviour change

- Pre-1971 timestamps are now **accepted** at signing. The int test asserting the old behaviour is replaced by two: a 1955 archive accepted, an absurd year 0218 still rejected.
- Files naming a digital recorder **and** claiming a pre-1971 date are rejected at ingest with an actionable message naming the recorder and explaining the flat-battery reset.
- All thresholds env-overridable: `MIN_RECORDING_YEAR` (1800), `MIN_DIGITAL_RECORDER_YEAR` (1971), `MAX_METADATA_DATE_DRIFT_DAYS` (366).

### Verified

- **21/21** new unit tests; eslint clean on all touched files.
- The 2 failing suites / 6 failing tests under `jest utils/ services/` are **pre-existing on clean master** (module-resolution in `services/db/uploads-switch.test.js`) — verified by running the same command on an unmodified checkout. This PR adds 21 passing tests and breaks none.
- Two apparent counter-examples in production both **strengthen** the rule: rows parsed as `1901-02-16` carry an AudioMoth comment reading *"Recorded at 06:00:00 17/02/2019"* (filename `160219010101.WAV` — DDMMYY read as YYMMDD). Correctly rejected, and the metadata even supplies the true date.

### Scope

Client-side mirror rides `rfcx/arbimon` @ `3165bfdce` (separate PR) so users are warned at staging rather than after an upload. Backfilling the 229,024 existing pre-1971 rows is deliberately not attempted here.
