### PR TITLE
ingest: accept AIFF uploads + stop an unprobeable trailing segment killing the whole ingest

### DIFF
--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -11,7 +11,7 @@ const arbimonService = require('../services/rfcx/arbimon')
 const auth0Service = require('../services/auth0')
 const moment = require('moment-timezone')
 const { getSampleRateFromFilename } = require('../services/rfcx/guardian')
-const { maxDurationWithGraceSeconds, maxDurationHoursDisplay, flacLimitSize, wavLimitSize, otherLimitSize } = require('../utils/limits')
+const { maxDurationWithGraceSeconds, maxDurationHoursDisplay, flacLimitSize, wavLimitSize, otherLimitSize, uncompressedExtensions } = require('../utils/limits')
 
 const maxBulkUploadCount = Number(process.env.UPLOAD_BULK_MAX_ITEMS || 100)
 // Parallelism for /uploads/bulk registration (2026-08-12 perf fix). Modest
@@ -140,11 +140,13 @@ async function validateUploadParams (params) {
   if (fileExtension === 'flac' && params.fileSize && params.fileSize > flacLimitSize) {
     throw new ValidationError(`This flac file size is exceeding our limit (${flacLimitSize / 1_000_000}MB)`)
   }
-  if (fileExtension === 'wav' && params.fileSize && params.fileSize > wavLimitSize) {
-    throw new ValidationError(`This wav file size is exceeding our limit (${wavLimitSize / 1_000_000}MB)`)
+  // WAV and AIFF are both uncompressed PCM -- same bytes for the same audio --
+  // so they share one cap (see utils/limits.js uncompressedExtensions).
+  if (uncompressedExtensions.includes(fileExtension) && params.fileSize && params.fileSize > wavLimitSize) {
+    throw new ValidationError(`This ${fileExtension} file size is exceeding our limit (${wavLimitSize / 1_000_000}MB)`)
   }
   // Other file extensions (e.g. opus)
-  if (!['flac', 'wav'].includes(fileExtension) && params.fileSize && params.fileSize > otherLimitSize) {
+  if (!['flac', ...uncompressedExtensions].includes(fileExtension) && params.fileSize && params.fileSize > otherLimitSize) {
     throw new ValidationError(`This file size is exceeding our limit (${otherLimitSize / 1_000_000}MB)`)
   }
   return params

--- a/services/audio.js
+++ b/services/audio.js
@@ -112,6 +112,10 @@ function identify (sourceFile) {
  * @param {Number} maxDuration - the maximum duration of a segment (in seconds)
  * @returns {Object[]} - array with objects with segments information (local path, duration)
  */
+// Sentinel for a trailing segment that ffprobe refused entirely (see the catch
+// inside split()). A unique object, so it can never collide with a real result.
+const TRAILING_DROPPED = Symbol('trailing-segment-dropped')
+
 function split (sourceFile, destinationPath, maxDuration) {
   destinationPath += destinationPath.endsWith('/') ? '' : '/'
   const outputFileFormat = destinationPath + path.basename(sourceFile).replace(/\.([^.]*)$/, '.%03d.$1') // convert hello.wav to hello.%03d.wav
@@ -144,7 +148,11 @@ function split (sourceFile, destinationPath, maxDuration) {
       })
       .on('end', function (stdout, stderr) {
         clearTimeout(timeout)
-        const outputFiles = stdout.trim().split('\n').map(async (x) => {
+        // Names of the segments ffmpeg reported, in order. Needed so a probe
+        // failure can tell a TRAILING runt (droppable) from an interior
+        // segment (a real fault) -- see the catch below.
+        const segmentNames = stdout.trim().split('\n')
+        const outputFiles = segmentNames.map(async (x) => {
           try {
             const filePath = path.join(destinationPath, x)
             const meta = await identify(filePath)
@@ -179,13 +187,76 @@ function split (sourceFile, destinationPath, maxDuration) {
               path: filePath,
               meta: meta
             }
-          } catch (e) { reject(e) }
+          } catch (e) {
+            // AN UNPROBEABLE TRAILING SEGMENT MUST NOT KILL THE WHOLE INGEST.
+            //
+            // Stream-copy segmentation can emit a runt final segment holding a
+            // PARTIAL frame, which ffprobe refuses outright rather than
+            // reporting badly:
+            //   [mp3] Invalid frame size (417): Could not seek to 879.
+            //   <file>: Invalid argument            (ffprobe exit 1)
+            // so identify() THROWS. Measured on mp3: this happens whenever the
+            // source length is an exact multiple of the segment length (60,
+            // 120, 180, 240, 300, 360, 420, 600s all reproduce) -- i.e. exactly
+            // the durations scheduled recorders produce.
+            //
+            // Previously this path called reject(e) and returned undefined,
+            // which ALSO left an undefined hole in the Promise.all array, so
+            // the .then() below threw a misleading
+            // "Cannot read properties of undefined (reading 'meta')" before the
+            // rejection surfaced -- masking the real cause.
+            //
+            // The runt carries NO audio (measured: 880 bytes, ffmpeg reports no
+            // decoded time, measureDecodedDuration() returns undefined), so
+            // dropping it loses nothing. This generalises the sampleCount guard
+            // below to the case where the segment cannot be probed AT ALL.
+            //
+            // Deliberately narrow: only a TRAILING segment is dropped. A
+            // mid-file probe failure is a real fault and must still fail the
+            // whole split, because silently discarding interior audio would
+            // corrupt the timeline.
+            //
+            // NOTE ON THE MECHANISM: we must SIGNAL the interior failure by
+            // returning a marker and re-throwing in the aggregation step below,
+            // NOT by calling reject() here. `resolve(Promise.all(...))` runs
+            // synchronously before any of these async callbacks settle, so this
+            // promise is already locked to that inner promise and a later
+            // reject() is a NO-OP. (That is precisely why the original code's
+            // reject(e) never surfaced and the caller saw the misleading
+            // "Cannot read properties of undefined" instead of the ffprobe
+            // error.) Caught by mutation testing: forcing isTrailing=false left
+            // the mp3 cases still passing, which they could only do if the
+            // interior branch were unreachable in effect.
+            const filePath = path.join(destinationPath, x)
+            const isTrailing = x === segmentNames[segmentNames.length - 1]
+            if (isTrailing) {
+              console.info(
+                `[segment-drop] trailing segment ${path.basename(filePath)} could not be probed ` +
+                `(${e && e.message}); dropping it -- it carries no decodable audio`
+              )
+              return TRAILING_DROPPED
+            }
+            return { __probeError: e, path: filePath }
+          }
         })
         /*
         * There is a very rare case that the segment is very small, 0.0000x second.
         * With this small segment, the sample count will be null so we have to exclude it
         */
         resolve(Promise.all(outputFiles).then(files => {
+          // An INTERIOR segment that could not be probed is a real fault: fail
+          // the split rather than silently shortening the recording.
+          const broken = files.find(f => f && f.__probeError)
+          if (broken) {
+            throw broken.__probeError
+          }
+          // Drop the trailing runt segment, if the catch above flagged one.
+          while (files.length && files[files.length - 1] === TRAILING_DROPPED) {
+            files.pop()
+          }
+          if (!files.length) {
+            throw new Error('No probeable segments were produced')
+          }
           if (!files[files.length - 1].meta.sampleCount) {
             files.pop()
           }

--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -16,9 +16,17 @@ const ingestBucket = process.env.INGEST_BUCKET
 const errorBucket = process.env.ERROR_BUCKET
 const uploadTargets = require('../uploads/upload-targets')
 
-const supportedExtensions = ['.wav', '.flac', '.opus']
-const losslessExtensions = ['.wav', '.flac']
-const extensionsRequiringConvToWav = ['.flac']
+// Accepted upload formats.
+//
+// AIFF (2026-08-14): added as a LOSSLESS format, handled exactly like FLAC --
+// decoded to WAV, split, then each segment encoded to FLAC. Measured against
+// the production ffmpeg (4.4.2) on 125s and 1200s fixtures: span drift 0.000s
+// at every duration tested, identical to WAV/FLAC, across standard 16-bit BE,
+// 24-bit, AIFF-C `sowt` (little-endian) and the 3-letter `.aif` spelling.
+// Both spellings are accepted because recorders and Mac tooling emit each.
+const supportedExtensions = ['.wav', '.flac', '.opus', '.aiff', '.aif']
+const losslessExtensions = ['.wav', '.flac', '.aiff', '.aif']
+const extensionsRequiringConvToWav = ['.flac', '.aiff', '.aif']
 
 const { IngestionError } = require('../../utils/errors')
 const { maxDurationWithGraceSeconds, maxDurationHoursDisplay } = require('../../utils/limits')

--- a/utils/limits.js
+++ b/utils/limits.js
@@ -22,7 +22,13 @@ function intFromEnv (name, fallback) {
 // FLAC may be large (already compressed). Default 1 GiB.
 const flacLimitSize = intFromEnv('MAX_FLAC_BYTES', 1_073_741_824)
 // WAV stays bounded (uncompressed -> expensive to process). Default 200 MB.
+// AIFF shares this cap: it is uncompressed PCM in a different container, so it
+// is the same size for the same audio (measured: 22,050,054 B AIFF vs
+// 22,050,078 B WAV for an identical 125s stereo 44.1kHz signal). Leaving it on
+// the `other` cap would reject AIFF files that are accepted as WAV.
 const wavLimitSize = intFromEnv('MAX_WAV_BYTES', 200_000_000)
+// Extensions that carry uncompressed PCM and therefore share the WAV cap.
+const uncompressedExtensions = ['wav', 'aiff', 'aif']
 // Anything else (e.g. opus) uses the same bound as WAV's old default. 150 MB.
 const otherLimitSize = intFromEnv('MAX_OTHER_BYTES', 150_000_000)
 
@@ -50,7 +56,7 @@ const splitTimeoutMs = intFromEnv('FFMPEG_SPLIT_TIMEOUT_MS', 15 * 60 * 1000)
  */
 function sizeLimitForExtension (fileExtension) {
   if (fileExtension === 'flac') { return flacLimitSize }
-  if (fileExtension === 'wav') { return wavLimitSize }
+  if (uncompressedExtensions.includes(fileExtension)) { return wavLimitSize }
   return otherLimitSize
 }
 
@@ -58,6 +64,7 @@ module.exports = {
   flacLimitSize,
   wavLimitSize,
   otherLimitSize,
+  uncompressedExtensions,
   maxDurationSeconds,
   durationGraceSeconds,
   maxDurationWithGraceSeconds,

--- a/utils/limits.test.js
+++ b/utils/limits.test.js
@@ -1,0 +1,33 @@
+const limits = require('./limits')
+
+describe('sizeLimitForExtension', () => {
+  test('flac gets the large (already-compressed) cap', () => {
+    expect(limits.sizeLimitForExtension('flac')).toBe(limits.flacLimitSize)
+  })
+
+  test('wav gets the uncompressed cap', () => {
+    expect(limits.sizeLimitForExtension('wav')).toBe(limits.wavLimitSize)
+  })
+
+  // AIFF is uncompressed PCM in a different container: byte-for-byte the same
+  // size as WAV for the same audio (measured 2026-08-14: 22,050,054 B AIFF vs
+  // 22,050,078 B WAV for an identical 125s stereo 44.1kHz signal). If it fell
+  // through to the `other` cap it would be rejected at 150 MB while the
+  // identical recording is accepted as WAV at 200 MB.
+  test.each(['aiff', 'aif'])('%s shares the WAV cap, not the other cap', (ext) => {
+    expect(limits.sizeLimitForExtension(ext)).toBe(limits.wavLimitSize)
+    expect(limits.sizeLimitForExtension(ext)).not.toBe(limits.otherLimitSize)
+  })
+
+  test('opus stays on the other cap', () => {
+    expect(limits.sizeLimitForExtension('opus')).toBe(limits.otherLimitSize)
+  })
+
+  test('an unknown extension falls back to the other cap', () => {
+    expect(limits.sizeLimitForExtension('xyz')).toBe(limits.otherLimitSize)
+  })
+
+  test('the uncompressed set is exactly wav + aiff spellings', () => {
+    expect([...limits.uncompressedExtensions].sort()).toEqual(['aif', 'aiff', 'wav'])
+  })
+})


### PR DESCRIPTION
Two changes, deliberately kept together because the second was found BY
testing the first, and the first is unsafe to ship without it.

The operator approved expanding the accepted upload formats to mp3, m4a,
ogg-vorbis and aiff. AIFF is the half that needed no further decision: it is
lossless, so it slots into the existing FLAC path with no policy question.
The lossy half is NOT included here -- it still needs an operator decision
(see OUT OF SCOPE below), and measurement changed what that decision should
be weighed on.

WHAT THIS COMMIT ADDS:
- services/rfcx/ingest.js: `.aiff` and `.aif` added to supportedExtensions,
  losslessExtensions and extensionsRequiringConvToWav -- i.e. handled exactly
  like FLAC (decode to WAV, split, encode each segment to FLAC). Both
  spellings, because recorders and Mac tooling emit each.
- utils/limits.js: new `uncompressedExtensions` set (wav/aiff/aif) so AIFF
  gets the 200 MB WAV cap instead of the 150 MB `other` cap. AIFF is
  uncompressed PCM in a different container: 22,050,054 B vs WAV's
  22,050,078 B for an identical 125 s stereo 44.1 kHz signal. Without this,
  a file accepted as WAV is rejected as AIFF at the same size.
- routes/uploads.js: the inline duplicate of that cap logic now uses the same
  set, so the two cannot drift.
- utils/limits.test.js: 7 tests over the cap mapping.

WHAT THIS COMMIT FIXES:
- services/audio.js: an unprobeable TRAILING segment no longer kills the
  ingest. Stream-copy segmentation can emit a runt final segment holding a
  partial frame, which ffprobe refuses outright ("Invalid frame size (417):
  Could not seek to 879", exit 1) rather than reporting it badly, so
  identify() throws.
  The old catch called reject(e) AND returned undefined. Both were wrong:
  `resolve(Promise.all(...))` runs synchronously before any of these
  callbacks settle, so the outer promise is already locked and the reject()
  is a NO-OP; meanwhile the undefined left a hole in the results array and
  the aggregation step threw "Cannot read properties of undefined (reading
  'meta')" -- which is why this class of failure has always surfaced as a
  confusing message instead of the real ffprobe error.
  Now: a trailing runt is dropped (it carries no audio -- 880 bytes, ffmpeg
  reports no decoded time, measureDecodedDuration() returns undefined), and
  an INTERIOR probe failure propagates the real error instead of silently
  shortening the recording.

VERIFIED (production-like container: ubuntu 22.04 + ffmpeg 4.4.2, matching
build/Dockerfile; run on the build tier, never the default docker context,
which points at a production DB VM):
- 26/26 checks pass, driving the REAL transcode()/split() code path.
- AIFF span drift 0.000 s across 16-bit BE, 24-bit, AIFF-C `sowt`
  (little-endian), the `.aif` spelling, and exact-multiple durations
  (120 s, 300 s) -- identical to WAV/FLAC, segments stored as .flac.
- Existing formats unchanged: wav/flac -0.001 s, opus -0.028 s, and the
  300 s opus case (the shape of the 108-row defect) -0.102 s.
- The trailing-segment guard: mp3 at 120/300/600 s previously died outright;
  now yields 2/5/10 segments summing 119.955/299.965/599.955 s.
- The guard is NARROW, proven behaviourally (not by grepping source): an
  injected interior probe failure still fails the split.
- The guard does not shorten healthy files: a 301.7 s wav still yields 6
  segments totalling 301.700 s, keeping the 1.698 s final segment.
- MUTATION TESTED 6/6 CAUGHT, zero survivors, each mutant verified present in
  its image first (a mutant that failed to apply is indistinguishable from a
  survivor). One mutant initially SURVIVED and that is what exposed the
  no-op reject() above -- the first version of the interior-failure check
  only grepped the source and passed vacuously.
- Repo suite: 139 passed vs 132 on pristine 88fa8da, same 6 pre-existing
  failures (local ffmpeg 8.x version-string artifact, confirmed identical on
  a clean baseline worktree before attributing). eslint clean on all four
  files.
- Downstream verified in the live media-api pod (ffmpeg 5.1.9 + SoX 14.4.2):
  media-api reads the segment extension from the DB and passes it to a plain
  `-i`, so it is input-format-agnostic; all 7 candidate containers demux and
  render to wav/flac/mp3/opus and through the sox spectrogram path. Pod
  scratch removed afterwards.

OUT OF SCOPE / DEFERRED:
- mp3 / m4a / ogg-vorbis: NOT accepted here. The operator has not chosen
  between pass-through and transcode-to-FLAC, and measurement says that
  choice should not be made on the mp3 failure (this commit fixes that
  independently) but on cost: transcoding to FLAC costs 0.81x for mp3,
  1.21x for m4a and 7.4x for ogg-vorbis. m4a and ogg pass through cleanly at
  all 16 durations tested; mp3 pass-through is now survivable but loses the
  (empty) trailing runt.
- Bit depth: 24-bit AIFF is reduced to 16-bit by the convert()->wav step.
  This is PRE-EXISTING, not introduced here -- 24-bit FLAC uploaded to
  production today is reduced identically (verified against 24-bit WAV as a
  control, which keeps 24-bit because it skips that step). Worth fixing, but
  it is a separate change with its own blast radius.
- Client side (SUPPORTED_EXTENSIONS + the picker's accept list) is a
  separate repo and is not touched here; the server accepting AIFF is a
  prerequisite for it, not the other way round.
- Recorder-metadata extraction stays WAV/FLAC-specific, so AIFF uploads will
  not yield GUANO/AudioMoth provenance. Known gap, unchanged by this commit.