### PR TITLE
fix(metrics): a /metrics scrape must never kill the process

### DIFF
--- a/routes/metrics.js
+++ b/routes/metrics.js
@@ -1,6 +1,23 @@
 const router = require('express').Router()
 const { PROMETHEUS_ENABLED, register } = require('../services/prometheus')
 
+/**
+ * @swagger
+ *
+ * /metrics:
+ *   get:
+ *        summary: Prometheus metrics
+ *        description: Prometheus scrape endpoint (501 when PROMETHEUS_ENABLED is not true)
+ *        tags:
+ *          - metrics
+ *        responses:
+ *          200:
+ *            description: Metrics in Prometheus text exposition format
+ *          500:
+ *            description: Metric collection failed
+ *          501:
+ *            description: Metrics are disabled
+ */
 router.route('/').get((req, res) => {
   if (!PROMETHEUS_ENABLED) {
     res.sendStatus(501)
@@ -10,6 +27,28 @@ router.route('/').get((req, res) => {
         res.setHeader('Content-Type', register.contentType)
         res.send(metrics)
         register.resetMetrics()
+      })
+      // DEFENCE IN DEPTH — this .catch() is load-bearing, do not remove it.
+      //
+      // `register.metrics()` gathers every registered metric under Promise.all.
+      // Without a .catch() here, ANY rejection from ANY collector escapes as an
+      // unhandledRejection, and utils/process-handlers.js deliberately
+      // process.exit(1)s on that — so a metrics scrape kills a serving pod.
+      // That is exactly the 2026-08-17/18 incident (~20 restarts per API
+      // replica); see services/prometheus.js for the full chain.
+      //
+      // services/prometheus.js now wraps OUR two DB-backed gauges so they
+      // cannot reject. This handler covers everything that wrapper cannot:
+      // prom-client's own collectDefaultMetrics, and any future gauge added
+      // without the wrapper. The two fixes are independent on purpose — the
+      // wrapper keeps a DB blip from losing the whole scrape, this keeps a
+      // scrape from ever losing the PROCESS.
+      //
+      // A failed scrape must be a 500 (Prometheus records the target as down
+      // and moves on), never a process exit.
+      .catch((err) => {
+        console.error('[metrics] scrape failed (non-fatal):', err && err.message)
+        res.sendStatus(500)
       })
   }
 })

--- a/routes/metrics.js
+++ b/routes/metrics.js
@@ -48,6 +48,14 @@ router.route('/').get((req, res) => {
       // and moves on), never a process exit.
       .catch((err) => {
         console.error('[metrics] scrape failed (non-fatal):', err && err.message)
+        // headersSent guard, same reasoning as middleware/error.js: this .catch()
+        // also covers anything that throws INSIDE the .then() ABOVE — notably
+        // resetMetrics() — by which point the body has already been sent.
+        // Calling sendStatus() then throws ERR_HTTP_HEADERS_SENT synchronously
+        // (verified), which would escape as an uncaughtException: the very class
+        // of crash this file exists to prevent. The scrape itself already
+        // succeeded in that case, so there is nothing to report to Prometheus.
+        if (res.headersSent) { return }
         res.sendStatus(500)
       })
   }

--- a/routes/metrics.test.js
+++ b/routes/metrics.test.js
@@ -98,6 +98,32 @@ describe('GET /metrics', () => {
     }
   })
 
+  test('a throw INSIDE .then (e.g. resetMetrics) does not double-send or crash', async () => {
+    // The .catch() also catches failures from the .then() body, by which point
+    // the response is already sent. sendStatus() would then throw
+    // ERR_HTTP_HEADERS_SENT synchronously and escape as an uncaughtException.
+    const seen = []
+    const onUnhandled = (reason) => seen.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const app = buildApp({
+        contentType: 'text/plain',
+        metrics: jest.fn().mockResolvedValue('some_metric 1'),
+        resetMetrics: jest.fn(() => { throw new Error('reset blew up after send') })
+      })
+
+      // The scrape itself succeeded, so the client still gets its 200 + body.
+      const res = await request(app).get('/metrics')
+      expect(res.status).toBe(200)
+      expect(res.text).toContain('some_metric 1')
+
+      await new Promise(resolve => setImmediate(resolve))
+      expect(seen).toEqual([])
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled)
+    }
+  })
+
   test('does not reset the register when collection failed', async () => {
     // resetMetrics is pushgateway-style: resetting after a FAILED gather would
     // discard histogram observations that were never actually exported.

--- a/routes/metrics.test.js
+++ b/routes/metrics.test.js
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------
+// The /metrics ROUTE must never let a rejection escape (2026-08-18).
+//
+// This is the SECOND half of the crash-loop fix, independent of the collector
+// wrapper in services/prometheus.js:
+//
+//   services/prometheus.js  -> stops OUR two DB-backed gauges rejecting at all
+//   routes/metrics.js       -> stops ANY rejection escaping the route
+//
+// Both are needed. The wrapper cannot cover prom-client's own
+// collectDefaultMetrics, nor a future gauge added without it. Without the
+// route's .catch(), such a rejection becomes an unhandledRejection and
+// utils/process-handlers.js deliberately process.exit(1)s — a metrics scrape
+// killing a serving pod, which is the 2026-08-17/18 incident.
+//
+// Ref: runbooks/FINDING-ingest-api-metrics-crashloop-2026-08-18.md (rfcx-local)
+// ---------------------------------------------------------------------------
+
+const express = require('express')
+const request = require('supertest')
+
+const BLIP = 'Connection terminated due to connection timeout'
+
+// Rebuild the route against a controllable register, mirroring routes/metrics.js.
+// (The real module reads PROMETHEUS_ENABLED at require time from env, so we mock
+// the seam rather than fight module-level state.)
+const buildApp = (registerMock, enabled = true) => {
+  jest.resetModules()
+  jest.doMock('../services/prometheus', () => ({
+    PROMETHEUS_ENABLED: enabled,
+    register: registerMock
+  }))
+  const app = express()
+  app.use('/metrics', require('./metrics'))
+  return app
+}
+
+let errorSpy
+beforeEach(() => {
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => {
+  errorSpy.mockRestore()
+  jest.resetModules()
+})
+
+describe('GET /metrics', () => {
+  test('serves metrics and resets the register on success', async () => {
+    const resetMetrics = jest.fn()
+    const app = buildApp({
+      contentType: 'text/plain; version=0.0.4; charset=utf-8',
+      metrics: jest.fn().mockResolvedValue('some_metric 1'),
+      resetMetrics
+    })
+
+    const res = await request(app).get('/metrics')
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('some_metric 1')
+    expect(resetMetrics).toHaveBeenCalled()
+  })
+
+  test('501 when metrics are disabled', async () => {
+    const app = buildApp({ metrics: jest.fn() }, false)
+    const res = await request(app).get('/metrics')
+    expect(res.status).toBe(501)
+  })
+
+  // THE REGRESSION GUARD.
+  test('returns 500 (does NOT reject) when collection fails — the crash-loop guard', async () => {
+    const app = buildApp({
+      contentType: 'text/plain',
+      metrics: jest.fn().mockRejectedValue(new Error(BLIP)),
+      resetMetrics: jest.fn()
+    })
+
+    const res = await request(app).get('/metrics')
+    expect(res.status).toBe(500)
+    expect(errorSpy.mock.calls.flat().join(' ')).toContain(BLIP)
+  })
+
+  test('a failed scrape emits NO unhandledRejection — the process must survive', async () => {
+    const seen = []
+    const onUnhandled = (reason) => seen.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const app = buildApp({
+        contentType: 'text/plain',
+        metrics: jest.fn().mockRejectedValue(new Error(BLIP)),
+        resetMetrics: jest.fn()
+      })
+
+      await request(app).get('/metrics')
+      // give any stray microtask-scheduled rejection a chance to surface
+      await new Promise(resolve => setImmediate(resolve))
+      expect(seen).toEqual([])
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled)
+    }
+  })
+
+  test('does not reset the register when collection failed', async () => {
+    // resetMetrics is pushgateway-style: resetting after a FAILED gather would
+    // discard histogram observations that were never actually exported.
+    const resetMetrics = jest.fn()
+    const app = buildApp({
+      contentType: 'text/plain',
+      metrics: jest.fn().mockRejectedValue(new Error(BLIP)),
+      resetMetrics
+    })
+
+    await request(app).get('/metrics')
+    expect(resetMetrics).not.toHaveBeenCalled()
+  })
+})

--- a/services/prometheus.js
+++ b/services/prometheus.js
@@ -3,14 +3,86 @@ let exp = {
   PROMETHEUS_ENABLED
 }
 
+// ---------------------------------------------------------------------------
+// Gauge collectors must FAIL SOFT — a metrics scrape must never kill the process.
+//
+// THE BUG THIS FIXES (observed in production 2026-08-17/18, ~20 restarts on each
+// ingest-service-api replica and 14 on a tasks pod):
+//
+//   @rfcx/prometheus-metrics `Gauge` takes a callback and awaits it inside
+//   prom-client's `collect()` with NO error handling:
+//
+//       async collect () { const currentValue = await func(); this.set(currentValue) }
+//
+//   prom-client gathers gauges under `Promise.all` in `registry.metrics()`, so a
+//   rejected callback becomes an UNHANDLED REJECTION. `utils/process-handlers.js`
+//   deliberately calls `process.exit(1)` on unhandledRejection (correct for the
+//   consumer — a swallowed rejection once left a pod up but NOT consuming), so a
+//   transient DB blip during a /metrics scrape TOOK THE POD DOWN:
+//
+//       error: GET 500 /health-check Response Time: 2003
+//       Unhandled promise rejection (will exit)
+//         message: 'Connection terminated due to connection timeout'
+//         at async Gauge.collect (@rfcx/prometheus-metrics/index.js:40:30)
+//         at async Promise.all (index 31)
+//
+//   Prometheus scrapes every 30s (platform/monitoring/43-ingest-servicemonitors.yaml),
+//   which made observability a LIVENESS DEPENDENCY on Postgres. The 2001-2003ms
+//   timings are exactly the pool's `connectionTimeoutMillis: 2000` — failures to
+//   ACQUIRE a connection, not slow queries (the gauge queries themselves are
+//   index-only and take 0.3-2.1ms against `stream_uploads_gauge_status_idx`).
+//
+// THE FIX: wrap each collector so a failure yields a STALE/ZERO sample and a log
+// line instead of an unhandled rejection. These are advisory counters; losing one
+// scrape is a non-event, losing the pod is not.
+//
+// WHY LAST-GOOD RATHER THAN 0: returning 0 on failure makes the gauge briefly LIE
+// (a dip to zero), which is indistinguishable from "the failure count really did
+// drop to zero" and could quietly satisfy or fire threshold alerts. Serving the
+// last good value keeps the series flat across a blip — visibly stale rather than
+// actively wrong. Before the first successful read there is no last-good value,
+// so we return 0 and say so in the log.
+//
+// NOTE the deliberate non-goals: the short `connectionTimeoutMillis` stays (the
+// readinessProbe with failureThreshold:1 shares this pool, so a long connect
+// timeout would turn a brief blip into a rolling readiness failure), and the
+// unhandledRejection->exit policy stays everywhere else.
+//
+// Ref: runbooks/FINDING-ingest-api-metrics-crashloop-2026-08-18.md (rfcx-local)
+// ---------------------------------------------------------------------------
+function nonFatalCollector (fn, label) {
+  let lastGood
+  return async () => {
+    try {
+      const value = await fn()
+      // Guard against a backend returning a non-number (pg returns bigint as a
+      // string; the pg impl already Number()s it, but a future backend might not).
+      // prom-client would throw on a non-number, back inside the same
+      // unhandled-rejection path this wrapper exists to prevent.
+      const numeric = Number(value)
+      if (!Number.isFinite(numeric)) {
+        throw new Error(`collector returned a non-numeric value: ${JSON.stringify(value)}`)
+      }
+      lastGood = numeric
+      return numeric
+    } catch (err) {
+      const detail = lastGood === undefined
+        ? 'no previous value yet, reporting 0'
+        : `reporting last good value ${lastGood}`
+      console.error(`[metrics] gauge "${label}" collect failed (non-fatal, ${detail}):`, err && err.message)
+      return lastGood === undefined ? 0 : lastGood
+    }
+  }
+}
+
 if (PROMETHEUS_ENABLED) {
   const { Histogram, Gauge, getRegister } = require('@rfcx/prometheus-metrics')
   const registerName = `ingest-service-${process.env.NODE_ENV || 'dev'}`
   const register = getRegister(registerName)
   const db = require('../services/db/uploads')
 
-  new Gauge(registerName, 'uploads_failed', 'Number or failed uploads', db.getUploadFailedCount) // eslint-disable-line no-new
-  new Gauge(registerName, 'uploads_duplicated', 'Number or duplicated uploads', db.getUploadDuplicateCount) // eslint-disable-line no-new
+  new Gauge(registerName, 'uploads_failed', 'Number or failed uploads', nonFatalCollector(db.getUploadFailedCount, 'uploads_failed')) // eslint-disable-line no-new
+  new Gauge(registerName, 'uploads_duplicated', 'Number or duplicated uploads', nonFatalCollector(db.getUploadDuplicateCount, 'uploads_duplicated')) // eslint-disable-line no-new
 
   const histograms = {}
 
@@ -33,5 +105,9 @@ if (PROMETHEUS_ENABLED) {
     register
   }
 }
+
+// Exported unconditionally (and regardless of PROMETHEUS_ENABLED) so it is
+// unit-testable without standing up a register or a database.
+exp.nonFatalCollector = nonFatalCollector
 
 module.exports = exp

--- a/services/prometheus.test.js
+++ b/services/prometheus.test.js
@@ -1,0 +1,168 @@
+// ---------------------------------------------------------------------------
+// A metrics scrape must NEVER kill the process (2026-08-18).
+//
+// Production incident: ~20 restarts on each ingest-service-api replica (and 14
+// on a tasks pod) because @rfcx/prometheus-metrics' Gauge awaits its callback
+// with no error handling, prom-client gathers gauges under Promise.all, and
+// utils/process-handlers.js deliberately exits on unhandledRejection. A DB blip
+// during the 30s Prometheus scrape therefore took the pod down.
+//
+// These tests pin the wrapper's contract AND reproduce the real mechanism
+// end-to-end through actual prom-client, so a regression cannot pass by only
+// satisfying the unit-level assertions.
+//
+// Ref: runbooks/FINDING-ingest-api-metrics-crashloop-2026-08-18.md (rfcx-local)
+// ---------------------------------------------------------------------------
+
+const { nonFatalCollector } = require('./prometheus')
+
+const DB_BLIP = () => new Error('Connection terminated due to connection timeout')
+
+let errorSpy
+beforeEach(() => {
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => {
+  errorSpy.mockRestore()
+})
+
+describe('nonFatalCollector', () => {
+  test('passes a successful value straight through', async () => {
+    const collect = nonFatalCollector(async () => 42, 'uploads_failed')
+    await expect(collect()).resolves.toBe(42)
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  test('RESOLVES (never rejects) when the underlying query fails — the whole point', async () => {
+    const collect = nonFatalCollector(async () => { throw DB_BLIP() }, 'uploads_failed')
+    await expect(collect()).resolves.toBe(0)
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  test('reports 0 when it fails before any successful read', async () => {
+    const collect = nonFatalCollector(async () => { throw DB_BLIP() }, 'uploads_failed')
+    await expect(collect()).resolves.toBe(0)
+    expect(errorSpy.mock.calls[0].join(' ')).toContain('no previous value yet')
+  })
+
+  test('serves the LAST GOOD value on a later failure, rather than dipping to 0', async () => {
+    // A dip to 0 is indistinguishable from a real drop to zero and could
+    // silently satisfy or fire a threshold alert. Staleness is the safer lie.
+    let mode = 'ok'
+    const collect = nonFatalCollector(async () => {
+      if (mode === 'fail') { throw DB_BLIP() }
+      return 7
+    }, 'uploads_failed')
+
+    await expect(collect()).resolves.toBe(7)
+    mode = 'fail'
+    await expect(collect()).resolves.toBe(7)
+    expect(errorSpy.mock.calls[0].join(' ')).toContain('last good value 7')
+  })
+
+  test('recovers to live values once the DB comes back', async () => {
+    let mode = 'ok'
+    const collect = nonFatalCollector(async () => {
+      if (mode === 'fail') { throw DB_BLIP() }
+      return mode === 'ok' ? 3 : 99
+    }, 'uploads_duplicated')
+
+    await expect(collect()).resolves.toBe(3)
+    mode = 'fail'
+    await expect(collect()).resolves.toBe(3)
+    mode = 'recovered'
+    await expect(collect()).resolves.toBe(99)
+  })
+
+  test('treats a non-numeric result as a failure (prom-client would throw on it)', async () => {
+    // pg returns bigint as a string; a backend that forgets to Number() it would
+    // otherwise throw INSIDE prom-client — the same unhandled-rejection path.
+    const collect = nonFatalCollector(async () => ({ rows: [{ count: '5' }] }), 'uploads_failed')
+    await expect(collect()).resolves.toBe(0)
+    expect(errorSpy.mock.calls[0].join(' ')).toContain('non-numeric')
+  })
+
+  test('coerces a numeric STRING (pg bigint shape) rather than rejecting it', async () => {
+    const collect = nonFatalCollector(async () => '12', 'uploads_failed')
+    await expect(collect()).resolves.toBe(12)
+  })
+
+  test('survives a synchronously-throwing collector, not just a rejected promise', async () => {
+    const collect = nonFatalCollector(() => { throw DB_BLIP() }, 'uploads_failed')
+    await expect(collect()).resolves.toBe(0)
+  })
+
+  test('names the failing gauge in the log so the cause is identifiable in seconds', async () => {
+    const collect = nonFatalCollector(async () => { throw DB_BLIP() }, 'uploads_duplicated')
+    await collect()
+    expect(errorSpy.mock.calls[0].join(' ')).toContain('uploads_duplicated')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// END-TO-END REPRODUCTION through real prom-client + the real Gauge shape.
+//
+// This is the test that actually proves the incident cannot recur: it drives
+// `registry.metrics()` (the exact call the /metrics route makes) with a failing
+// DB-backed gauge, under a listener that fails the test on unhandledRejection.
+// ---------------------------------------------------------------------------
+describe('registry.metrics() with a failing DB-backed gauge (real prom-client)', () => {
+  const client = require('prom-client')
+
+  // Mirrors @rfcx/prometheus-metrics' Gauge exactly — an async collect() that
+  // awaits the supplied callback. That package is a third-party dependency we
+  // cannot patch, so the wrapper is applied at the CALL SITE; this reproduces
+  // the vulnerable shape to prove the wrapper neutralises it.
+  const makeVendorGauge = (register, name, func) => {
+    const gauge = new client.Gauge({
+      name,
+      help: name,
+      async collect () { this.set(await func()) }
+    })
+    register.registerMetric(gauge)
+    return gauge
+  }
+
+  test('UNWRAPPED collector rejects the scrape — the bug, reproduced', async () => {
+    const register = new client.Registry()
+    makeVendorGauge(register, 'repro_unwrapped', async () => { throw DB_BLIP() })
+    // This rejection is what became an unhandledRejection -> process.exit(1).
+    await expect(register.metrics()).rejects.toThrow('Connection terminated')
+  })
+
+  test('WRAPPED collector lets the scrape SUCCEED and still serves the metric', async () => {
+    const register = new client.Registry()
+    makeVendorGauge(register, 'repro_wrapped', nonFatalCollector(async () => { throw DB_BLIP() }, 'repro_wrapped'))
+
+    const output = await register.metrics()
+    expect(output).toContain('repro_wrapped 0')
+  })
+
+  test('a failing gauge does not poison OTHER metrics in the same scrape', async () => {
+    // The real registry gathers under Promise.all — one rejection fails the
+    // whole scrape, taking healthy metrics with it.
+    const register = new client.Registry()
+    makeVendorGauge(register, 'repro_healthy', nonFatalCollector(async () => 5, 'repro_healthy'))
+    makeVendorGauge(register, 'repro_broken', nonFatalCollector(async () => { throw DB_BLIP() }, 'repro_broken'))
+
+    const output = await register.metrics()
+    expect(output).toContain('repro_healthy 5')
+    expect(output).toContain('repro_broken 0')
+  })
+
+  test('no unhandledRejection is emitted across a failing scrape', async () => {
+    const seen = []
+    const onUnhandled = (reason) => seen.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const register = new client.Registry()
+      makeVendorGauge(register, 'repro_no_unhandled', nonFatalCollector(async () => { throw DB_BLIP() }, 'repro_no_unhandled'))
+      await register.metrics()
+      // let any stray microtask-scheduled rejection surface
+      await new Promise(resolve => setImmediate(resolve))
+      expect(seen).toEqual([])
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled)
+    }
+  })
+})


### PR DESCRIPTION
## The incident

**~20 restarts on each `ingest-service-api` replica** (and 14 on a tasks pod) on 2026-08-17/18. Both replicas, both node hosts, tasks too — so not a bad pod and not a bad node.

```
error: GET 500 /health-check Response Time: 2003
Unhandled promise rejection (will exit) {
  service: 'ingest-service-api',
  message: 'Connection terminated due to connection timeout',
  stack: 'at async Gauge.collect (@rfcx/prometheus-metrics/index.js:40:30)
          at async Promise.all (index 31)
          at async Registry.metrics (prom-client/lib/registry.js:60:20)'
}
error Command failed with exit code 1.
```

## Root cause — three links, each verified in source

1. **`@rfcx/prometheus-metrics`' `Gauge` awaits its callback with no error handling:**
   ```js
   async collect () { const currentValue = await func(); this.set(currentValue) }
   ```
2. **prom-client gathers gauges under `Promise.all`** in `registry.metrics()`, so a rejected callback becomes an unhandled rejection.
3. **`utils/process-handlers.js` deliberately `process.exit(1)`s on `unhandledRejection`** — which is *correct* and load-bearing for the consumer (a swallowed rejection once left a pod up but NOT consuming, queue stalled at 0 consumers).

Prometheus scrapes `/metrics` **every 30s**, so this made **observability a liveness dependency on Postgres**. A transient connect failure during a scrape took the pod down.

**The `2001`/`2002`/`2003` ms timings are exactly the pool's `connectionTimeoutMillis: 2000`** — failures to *acquire* a connection, not slow queries. The gauge queries themselves are index-only and take **0.3–2.1 ms** (`stream_uploads_gauge_status_idx`, partial on `status IN (30,31)`).

Trigger was environmental — a Patroni failover + `patronictl reinit` basebackup on a zero-slack node. It **self-resolved** when the replica finished rebuilding. **The fragility did not.**

## The fix

Wrap both collectors so a failure yields a stale/zero sample plus a log line instead of an unhandled rejection. **The functional diff is two lines**; the rest is the wrapper, the rationale comment, and tests.

**Why last-good rather than `0`:** a dip to zero is indistinguishable from a real drop to zero, and could quietly satisfy or fire a threshold alert. Staleness is *visibly* stale; a zero is *actively wrong*. Before any successful read there is no last-good value, so it reports 0 and says so in the log.

Also treats a **non-numeric result as a failure** — pg returns bigint as a string, and a backend that forgot to `Number()` it would otherwise throw *inside* prom-client, i.e. straight back into the same unhandled-rejection path.

### Deliberate non-goals
- **`connectionTimeoutMillis` stays short.** The readinessProbe (`failureThreshold: 1`) shares this pool; a long connect timeout would turn a brief blip into a rolling readiness failure across every replica. The in-code comment says so.
- **The `unhandledRejection` → exit policy stays everywhere else.** Only the metrics path loses its ability to kill the process.

## Tests — 13, all passing

Unit contract for the wrapper, plus an **end-to-end reproduction through real prom-client** that proves (a) an **unwrapped** collector rejects the scrape — the bug itself — and (b) the wrapped one succeeds, doesn't poison other metrics in the same scrape, and emits no `unhandledRejection`.

**Mutation-tested** (a test that passes with the fix disabled is worthless):

| mutation | result |
|---|---|
| neuter the wrapper (rethrow) | **10 of 13 fail** |
| replace last-good with always-0 | **the 2 last-good tests fail** |

## Gates

- Full-repo `eslint "**/*.js"` → **exit 0**
- Suite delta vs master baseline: **132 → 145 passing, 188 → 201 total**
- **Same 2 suites / 6 tests fail on both sides** (`audio.test.js`, `uploads-switch.test.js` — a locally-missing `bson-objectid`). Pre-existing and environmental, **verified by running the baseline on clean master** rather than assumed.
- Lint fixed **by hand**, not `eslint --fix` (it has previously corrupted source in this org).

## Verified in-pod against the live production image

Ran against `ingest-service:rfcx-local-prod-7e742f8` using the **real** `@rfcx/prometheus-metrics` + `prom-client`, writing only to `/tmp` and touching no running code:

```
unwrapped scrape rejects (bug reproduced in-pod): true
wrapped scrape SUCCEEDS: true
last-good served (7 then 7): true
unhandledRejection count: 0
IN-POD VERIFY: PASS
```

Temp files removed afterwards; pod restart counts unchanged (no restarts caused by the verification).

## Deploy notes

- Targets **`master`** (`develop` deploys nowhere).
- **ingest is a three-pin family:** CD's matrix rolls `api` + `tasks` only — the `upload-source-cleanup` CronJob is hand-rolled each release.
- Instant mitigation if this ever recurs before a fix ships: `PROMETHEUS_ENABLED` is a ConfigMap key (costs the dashboards).

Ref: `runbooks/FINDING-ingest-api-metrics-crashloop-2026-08-18.md` + rfcx-local PR #1054.