### PR TITLE
fix(ingest): retry segment PUTs on the s3-writer's in-flight PUT limit signal

### DIFF
--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -30,6 +30,7 @@ const extensionsRequiringConvToWav = ['.flac', '.aiff', '.aif']
 
 const { IngestionError } = require('../../utils/errors')
 const { maxDurationWithGraceSeconds, maxDurationHoursDisplay } = require('../../utils/limits')
+const { retryOnPutLimit } = require('../../utils/put-retry')
 const loggerIgnoredErrors = [
   /Duplicate file\. Matching sha1 signature already ingested\./,
   /This file was already ingested\./,
@@ -48,6 +49,13 @@ if (PROMETHEUS_ENABLED) {
   Object.keys(db.status).forEach((s) => {
     registerHistogram(s, `${s} upload status.`, [1, 2, 3, 4, 5, 10, 50, 100, 250, 500, 1000, 2000])
   })
+  // Segment-PUT bulkhead-retry observability (2026-08-19): the capacity
+  // decision that led to the s3-writer-ingest KEDA floor/cap had to be made
+  // from log greps. Count retries and exhaustions so the next one is made
+  // from data. House convention: histograms pushed with value 1 act as
+  // counters (same as the status metrics above).
+  registerHistogram('put_limit_retry', 'Segment PUTs retried after an s3-writer in-flight PUT limit rejection.', [1, 2, 3, 4, 5, 10, 50, 100, 250, 500, 1000, 2000])
+  registerHistogram('put_limit_exhausted', 'Segment PUTs that exhausted all put-limit retries and failed the ingest.', [1, 2, 3, 4, 5, 10, 50, 100, 250, 500, 1000, 2000])
 }
 
 /**
@@ -318,13 +326,37 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
     tracker.setPoint()
     let processedSegCount = 0
     for (const chunk of [...chunks(outputFiles, 5)]) {
+      // Each segment PUT retries ONLY the s3-writer's in-flight PUT bulkhead
+      // rejection (503 SlowDown "in-flight PUT limit reached; retry") with
+      // bounded jittered backoff — see utils/put-retry.js for the 2026-08-19
+      // incident and the >5s-per-attempt rationale (the writer's own acquire
+      // window is 5s, so each retry sees a fresh window). ANY other error
+      // still fails fast on the first attempt, and an exhausted retry
+      // re-throws the last throttle error raw — so the rollback + status 30 +
+      // nack->DLQ path below is byte-identical to before for every non-
+      // throttle failure and for genuine sustained saturation. The retry
+      // wraps ONLY this PUT phase: segment keys (f.remotePath) were minted
+      // from Core data before this loop and are stable across attempts, so a
+      // re-PUT is an idempotent overwrite; the queue message is not acked
+      // until the whole ingest settles (consumer semantics untouched).
       await Promise.all(chunk.map((f) => {
-        return storage.upload(ingestBucket, f.remotePath, f.path)
-          .then((data) => {
-            if (!data || !data.ETag) {
-              throw new Error('Error while uploading file to storage')
+        return retryOnPutLimit(
+          () => storage.upload(ingestBucket, f.remotePath, f.path),
+          {
+            onRetry: ({ attempt, delayMs, error }) => {
+              console.warn(`[${uploadId}] s3-writer PUT limit hit for ${f.remotePath} (attempt ${attempt}); retrying in ${delayMs}ms: ${error && error.message}`)
+              if (PROMETHEUS_ENABLED) { pushHistogramMetric('put_limit_retry', 1) }
+            },
+            onExhausted: (error) => {
+              console.error(`[${uploadId}] s3-writer PUT limit retries exhausted for ${f.remotePath}: ${error && error.message}`)
+              if (PROMETHEUS_ENABLED) { pushHistogramMetric('put_limit_exhausted', 1) }
             }
-          })
+          }
+        ).then((data) => {
+          if (!data || !data.ETag) {
+            throw new Error('Error while uploading file to storage')
+          }
+        })
       }))
       processedSegCount += chunk.length
       console.info(`[${uploadId}] Processed ${processedSegCount} recordings of ${outputFiles.length}`)

--- a/services/rfcx/ingest.test.js
+++ b/services/rfcx/ingest.test.js
@@ -264,6 +264,111 @@ describe('Test ingest service', () => {
     expect(storage.deleteObject).not.toHaveBeenCalled()
   })
 
+  // --- s3-writer PUT-limit retry (2026-08-19) -------------------------------
+  // The writer rejects segment PUTs with 503 SlowDown
+  // "s3-writer in-flight PUT limit reached; retry" under bulkhead saturation.
+  // These tests drive the REAL ingest pipeline (real transcode of the test
+  // fixture) with storage.upload stubbed to emit that shape, asserting
+  // (a) transient bursts self-heal into INGESTED with bounded retries,
+  // (b) sustained saturation exhausts -> rollback + FAILED + re-throw (nack
+  //     -> DLQ, redrivable) exactly as before the retry existed,
+  // (c) non-throttle PUT failures keep their fail-fast single-attempt path.
+  // Backoff knobs are env-shrunk so the suite doesn't sleep for real.
+
+  function slowDown () {
+    const err = new Error('s3-writer in-flight PUT limit reached; retry')
+    err.code = 'SlowDown'
+    err.statusCode = 503
+    return err
+  }
+
+  function shrinkRetryKnobs (attempts = 3) {
+    process.env.PUT_RETRY_ATTEMPTS = String(attempts)
+    process.env.PUT_RETRY_BASE_MS = '1'
+    process.env.PUT_RETRY_MAX_MS = '2'
+    process.env.PUT_RETRY_MIN_MS = '1'
+  }
+
+  test('PUT-limit rejections are retried and the ingest still succeeds', async () => {
+    const fileName = 'test-5mins-lv8.flac'
+    const pathFile = path.join(__dirname, '../../test/', fileName)
+    const tempFilePath = tempDirPath + fileName
+    process.env.CACHE_DIRECTORY = tempDirPath
+    shrinkRetryKnobs(3)
+    fs.copyFile(pathFile, tempFilePath, (err) => { console.info(err) })
+    const upload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+
+    // First TWO segment PUTs hit the bulkhead, then every attempt succeeds
+    // (the burst passed) — the 08-19 prod shape at ~12% failure rate.
+    let calls = 0
+    const uploadSpy = jest.spyOn(storage, 'upload').mockImplementation(() => {
+      calls += 1
+      if (calls <= 2) { return Promise.reject(slowDown()) }
+      return Promise.resolve({ ETag: true })
+    })
+
+    await ingestService.ingest(`${UPLOAD.streamId}/${fileName}`, tempFilePath, UPLOAD.streamId, upload.id)
+
+    const newUpload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+    expect(newUpload.status).toBe(status.INGESTED)
+    // 5 segments + 2 retried attempts = 7 total PUT calls; no rollback.
+    expect(uploadSpy).toHaveBeenCalledTimes(7)
+    expect(storage.deleteObject).not.toHaveBeenCalled()
+  })
+
+  test('Exhausted PUT-limit retries roll back and nack exactly like before (bounded attempts)', async () => {
+    const fileName = 'test-5mins-lv8.flac'
+    const pathFile = path.join(__dirname, '../../test/', fileName)
+    const tempFilePath = tempDirPath + fileName
+    process.env.CACHE_DIRECTORY = tempDirPath
+    shrinkRetryKnobs(3)
+    fs.copyFile(pathFile, tempFilePath, (err) => { console.info(err) })
+    const upload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+
+    // Sustained saturation: every PUT attempt is rejected.
+    const uploadSpy = jest.spyOn(storage, 'upload').mockRejectedValue(slowDown())
+
+    // Must RE-THROW (consumer nacks to DLQ — transient class, redrivable).
+    await expect(
+      ingestService.ingest(`${UPLOAD.streamId}/${fileName}`, tempFilePath, UPLOAD.streamId, upload.id)
+    ).rejects.toThrow(/in-flight PUT limit reached/)
+
+    const newUpload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+    expect(newUpload.status).toBe(status.FAILED)
+    expect(newUpload.failureMessage).toBe('Server failed with processing your file. Please try again later.')
+    // BOUNDED: 5 segments x 3 attempts each = 15, not unbounded.
+    expect(uploadSpy).toHaveBeenCalledTimes(15)
+    // Rollback ran: every registered segment was deleted.
+    expect(storage.deleteObject).toHaveBeenCalledTimes(5)
+    // Core rollback ran too (source file had been created).
+    expect(segmentService.deleteStreamSourceFile).toHaveBeenCalledTimes(1)
+  })
+
+  test('Non-throttle PUT failure keeps the fail-fast single-attempt path', async () => {
+    const fileName = 'test-5mins-lv8.flac'
+    const pathFile = path.join(__dirname, '../../test/', fileName)
+    const tempFilePath = tempDirPath + fileName
+    process.env.CACHE_DIRECTORY = tempDirPath
+    shrinkRetryKnobs(3)
+    fs.copyFile(pathFile, tempFilePath, (err) => { console.info(err) })
+    const upload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+
+    const err = new Error('Access Denied')
+    err.code = 'AccessDenied'
+    err.statusCode = 403
+    const uploadSpy = jest.spyOn(storage, 'upload').mockRejectedValue(err)
+
+    await expect(
+      ingestService.ingest(`${UPLOAD.streamId}/${fileName}`, tempFilePath, UPLOAD.streamId, upload.id)
+    ).rejects.toThrow('Access Denied')
+
+    const newUpload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+    expect(newUpload.status).toBe(status.FAILED)
+    // NO retry on non-throttle errors: exactly one attempt per segment in
+    // the first parallel chunk of 5, none re-attempted.
+    expect(uploadSpy).toHaveBeenCalledTimes(5)
+  })
+
   test('Pre-transcode dedup ACK-drops (coreData empty => no rollback crash)', async () => {
     // Regression: the pre-transcode dedup path throws DUPLICATE BEFORE
     // createStreamFileData runs, leaving coreData = {} (truthy). The catch

--- a/utils/put-retry.js
+++ b/utils/put-retry.js
@@ -1,0 +1,121 @@
+// Bounded, jittered-exponential retry for ONE specific segment-PUT failure:
+// the s3-writer's in-flight PUT bulkhead rejection (503 SlowDown,
+// "s3-writer in-flight PUT limit reached; retry").
+//
+// WHY THIS EXISTS (2026-08-19 production incident): a single browser
+// bulk-backfill sustained ~12% TERMINAL upload failures because the task
+// pipeline treated the writer's explicit backpressure signal — whose message
+// literally says "retry" — as a fatal error: full rollback, status 30
+// (FAILED), "Server failed with processing your file. Please try again
+// later." None of the 111 failed files were ever re-ingested; bulk users do
+// not click per-file Retry. Capacity bumps (replicas 3→4, then KEDA floor
+// 4 / cap 6) reduce collision frequency but the cap is finite — any burst
+// beyond it converts transient backpressure into permanent user-visible
+// failure. The in-task retry fixes the CLASS.
+//
+// SCOPE CONSTRAINTS (deliberate — read before widening):
+//   - Retries ONLY the throttle signal (SlowDown / the writer's message).
+//     Every other error propagates untouched on the FIRST attempt, so all
+//     existing classification (services/rfcx/segments.js terminal switch,
+//     the 2026-06-30 data-loss-adjacent handled-terminal rules, DLQ nack
+//     semantics) is byte-identical for non-throttle failures.
+//   - When retries exhaust, the LAST throttle error is re-thrown raw. The
+//     caller's catch path (rollback + status 30 + nack->DLQ) is unchanged,
+//     so an exhausted burst remains operator-redriveable exactly as today.
+//   - Re-PUT of the same segment key is safe: keys are minted from Core
+//     data BEFORE the upload loop and are stable across attempts (S3 PUT is
+//     an idempotent overwrite); a retry never re-mints keys.
+//
+// BACKOFF SHAPE: the writer holds a PUT slot-acquire window of
+// PUT_ACQUIRE_TIMEOUT = 5s before rejecting, so any retry delay must exceed
+// ~5s for the next attempt to see a FRESH window rather than re-joining the
+// same saturated one (a sub-5s retry is exactly what the aws-sdk's built-in
+// fast retries already tried, and lost). Hence the >5s floor. Defaults:
+// 5 attempts, base 6s doubling to an 18s cap, ±30% jitter =>
+// ~6+12+18+18 = 54s nominal total (range ~38-70s), floor-clamped to 5.5s.
+//
+// All knobs are env-tunable (read per call, so tests can override):
+//   PUT_RETRY_ATTEMPTS (total attempts incl. the first; default 5)
+//   PUT_RETRY_BASE_MS  (first retry delay; default 6000)
+//   PUT_RETRY_MAX_MS   (delay cap; default 18000)
+//   PUT_RETRY_MIN_MS   (floor after jitter; default 5500 — see above)
+
+const JITTER = 0.3
+
+function envInt (name, dflt) {
+  const v = parseInt(process.env[name], 10)
+  return Number.isFinite(v) && v > 0 ? v : dflt
+}
+
+/**
+ * True ONLY for the s3-writer PUT bulkhead rejection (or an upstream S3
+ * throttle, which carries the same standard SlowDown code and deserves the
+ * same treatment). aws-sdk v2 parses the writer's 503 XML into
+ * err.code === 'SlowDown' with the message text preserved; the message match
+ * is kept as a fallback so a proxy/SDK layer that mangles the code still
+ * classifies correctly.
+ * @param {Error} err
+ */
+function isPutLimitError (err) {
+  if (!err) { return false }
+  if (err.code === 'SlowDown') { return true }
+  const message = typeof err.message === 'string' ? err.message : ''
+  return /in-flight PUT limit reached/i.test(message)
+}
+
+/**
+ * Jittered exponential backoff, clamped to [minMs, maxMs].
+ * @param {number} attempt 1-based index of the attempt that just FAILED
+ * @param {{baseMs:number,maxMs:number,minMs:number}} o
+ * @param {() => number} rng 0..1
+ */
+function backoffDelayMs (attempt, o, rng) {
+  const exp = Math.min(o.baseMs * Math.pow(2, attempt - 1), o.maxMs)
+  const jittered = exp * (1 + JITTER * (2 * rng() - 1))
+  return Math.max(o.minMs, Math.round(Math.min(jittered, o.maxMs * (1 + JITTER))))
+}
+
+/**
+ * Run `fn`, retrying ONLY on isPutLimitError with bounded jittered
+ * exponential backoff. Any other error propagates immediately. On
+ * exhaustion the last throttle error is re-thrown raw.
+ *
+ * @param {(attempt: number) => Promise<any>} fn
+ * @param {object} [opts]
+ * @param {number} [opts.attempts] total attempts (>=1)
+ * @param {number} [opts.baseMs]
+ * @param {number} [opts.maxMs]
+ * @param {number} [opts.minMs]
+ * @param {(info: {attempt:number, delayMs:number, error:Error}) => void} [opts.onRetry]
+ *        called BEFORE each backoff sleep
+ * @param {(error: Error) => void} [opts.onExhausted] called once, before the final re-throw
+ * @param {(ms: number) => Promise<void>} [opts.sleep] injectable for tests
+ * @param {() => number} [opts.rng] injectable for tests
+ */
+async function retryOnPutLimit (fn, opts = {}) {
+  const o = {
+    attempts: opts.attempts || envInt('PUT_RETRY_ATTEMPTS', 5),
+    baseMs: opts.baseMs || envInt('PUT_RETRY_BASE_MS', 6000),
+    maxMs: opts.maxMs || envInt('PUT_RETRY_MAX_MS', 18000),
+    minMs: opts.minMs || envInt('PUT_RETRY_MIN_MS', 5500)
+  }
+  const sleep = opts.sleep || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+  const rng = opts.rng || Math.random
+  let lastError
+  for (let attempt = 1; attempt <= o.attempts; attempt++) {
+    try {
+      return await fn(attempt)
+    } catch (err) {
+      if (!isPutLimitError(err)) { throw err }
+      lastError = err
+      if (attempt === o.attempts) { break }
+      const delayMs = backoffDelayMs(attempt, o, rng)
+      if (opts.onRetry) { opts.onRetry({ attempt, delayMs, error: err }) }
+      await sleep(delayMs)
+    }
+  }
+  if (opts.onExhausted) { opts.onExhausted(lastError) }
+  throw lastError
+}
+
+module.exports = { isPutLimitError, backoffDelayMs, retryOnPutLimit }

--- a/utils/put-retry.test.js
+++ b/utils/put-retry.test.js
@@ -1,0 +1,175 @@
+const { isPutLimitError, backoffDelayMs, retryOnPutLimit } = require('./put-retry')
+
+// Test-fixture design note (mutation-tested; the standing 08-19 lesson is to
+// enumerate where correct/mutated behaviour diverges BEFORE writing fixtures):
+//   M1 "retry every error"        -> killed by 'non-throttle error fails fast'
+//   M2 "widen the loop bound"     -> EQUIVALENT MUTANT, justified survivor:
+//      the `if (attempt === o.attempts) break` line exhausts the sequence
+//      before a widened loop condition can matter (removing THAT line is M9,
+//      killed). The bound is enforced by the break, not the loop condition.
+//   M3 "drop the minMs floor"     -> killed by 'floor engages at negative jitter'
+//   M4 "drop the maxMs cap"       -> killed by 'delay pins at cap'
+//   M5 "swallow fn's return"      -> killed by 'returns the resolved value'
+//   M6 "keep retrying after a non-throttle mid-sequence" -> killed by
+//      'throttle then non-throttle throws the second error at attempt 2'
+//   M7 "classify on substring of code / any 503" -> killed by the
+//      isPutLimitError negative cases
+//   M8 "wrap the final error"     -> killed by rejects.toBe(errors[2]) (raw
+//      identity matters: ingest.js's catch classifies on the original error)
+//   M9 "drop the exhaustion break" -> killed by 'exhausts after exactly N'
+
+function slowDownError () {
+  const err = new Error('s3-writer in-flight PUT limit reached; retry')
+  err.code = 'SlowDown'
+  err.statusCode = 503
+  return err
+}
+
+const instantSleep = () => Promise.resolve()
+const midRng = () => 0.5 // jitter factor (2*0.5-1)=0 => no jitter
+
+describe('isPutLimitError', () => {
+  test('true for the aws-sdk parsed SlowDown code', () => {
+    expect(isPutLimitError(slowDownError())).toBe(true)
+  })
+  test('true on the writer message even without a code (mangling proxy/SDK layer)', () => {
+    expect(isPutLimitError(new Error('s3-writer in-flight PUT limit reached; retry'))).toBe(true)
+  })
+  test('message match is case-insensitive', () => {
+    expect(isPutLimitError(new Error('S3-WRITER IN-FLIGHT PUT LIMIT REACHED; RETRY'))).toBe(true)
+  })
+  test('false for other S3 errors, even 503s (M7)', () => {
+    const err = new Error('InternalError')
+    err.code = 'InternalError'
+    err.statusCode = 503
+    expect(isPutLimitError(err)).toBe(false)
+  })
+  test('false for a generic network error (M7)', () => {
+    expect(isPutLimitError(new Error('socket hang up'))).toBe(false)
+  })
+  test('false for null/undefined', () => {
+    expect(isPutLimitError(null)).toBe(false)
+    expect(isPutLimitError(undefined)).toBe(false)
+  })
+})
+
+describe('backoffDelayMs', () => {
+  const o = { baseMs: 6000, maxMs: 18000, minMs: 5500 }
+  test('exponential growth with no jitter: 6s, 12s, then pinned at the 18s cap (M4)', () => {
+    expect(backoffDelayMs(1, o, midRng)).toBe(6000)
+    expect(backoffDelayMs(2, o, midRng)).toBe(12000)
+    expect(backoffDelayMs(3, o, midRng)).toBe(18000)
+    expect(backoffDelayMs(4, o, midRng)).toBe(18000)
+  })
+  test('floor engages at full negative jitter (M3): 6000*0.7=4200 -> clamped to 5500 (> the writer 5s window)', () => {
+    expect(backoffDelayMs(1, o, () => 0)).toBe(5500)
+  })
+  test('positive jitter never exceeds maxMs*(1+jitter)', () => {
+    expect(backoffDelayMs(3, o, () => 1)).toBeLessThanOrEqual(18000 * 1.3)
+  })
+  test('every possible delay exceeds the writer 5s acquire window', () => {
+    for (const rng of [() => 0, () => 0.25, midRng, () => 0.75, () => 1]) {
+      for (let attempt = 1; attempt <= 5; attempt++) {
+        expect(backoffDelayMs(attempt, o, rng)).toBeGreaterThan(5000)
+      }
+    }
+  })
+})
+
+describe('retryOnPutLimit', () => {
+  test('returns the resolved value on first-attempt success (M5), no sleeps', async () => {
+    const sleep = jest.fn(instantSleep)
+    const fn = jest.fn().mockResolvedValue({ ETag: 'abc' })
+    const result = await retryOnPutLimit(fn, { attempts: 5, sleep, rng: midRng })
+    expect(result).toEqual({ ETag: 'abc' })
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  test('retries the throttle signal and returns the eventual success value (M5)', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(slowDownError())
+      .mockRejectedValueOnce(slowDownError())
+      .mockResolvedValue({ ETag: 'ok' })
+    const onRetry = jest.fn()
+    const result = await retryOnPutLimit(fn, { attempts: 5, sleep: instantSleep, rng: midRng, onRetry })
+    expect(result).toEqual({ ETag: 'ok' })
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(onRetry).toHaveBeenCalledTimes(2)
+    expect(onRetry.mock.calls[0][0]).toMatchObject({ attempt: 1, delayMs: 6000 })
+    expect(onRetry.mock.calls[1][0]).toMatchObject({ attempt: 2, delayMs: 12000 })
+  })
+
+  test('non-throttle error fails fast on the FIRST attempt (M1)', async () => {
+    const err = new Error('Access Denied')
+    err.code = 'AccessDenied'
+    const fn = jest.fn().mockRejectedValue(err)
+    const onRetry = jest.fn()
+    await expect(retryOnPutLimit(fn, { attempts: 5, sleep: instantSleep, onRetry })).rejects.toBe(err)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(onRetry).not.toHaveBeenCalled()
+  })
+
+  test('throttle then non-throttle throws the SECOND error at attempt 2 (M6)', async () => {
+    const other = new Error('socket hang up')
+    const fn = jest.fn()
+      .mockRejectedValueOnce(slowDownError())
+      .mockRejectedValueOnce(other)
+    await expect(retryOnPutLimit(fn, { attempts: 5, sleep: instantSleep, rng: midRng })).rejects.toBe(other)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  test('exhausts after exactly N attempts and re-throws the LAST throttle error raw (M2)', async () => {
+    const errors = [slowDownError(), slowDownError(), slowDownError()]
+    const fn = jest.fn()
+      .mockRejectedValueOnce(errors[0])
+      .mockRejectedValueOnce(errors[1])
+      .mockRejectedValueOnce(errors[2])
+    const onRetry = jest.fn()
+    const onExhausted = jest.fn()
+    await expect(retryOnPutLimit(fn, { attempts: 3, sleep: instantSleep, rng: midRng, onRetry, onExhausted }))
+      .rejects.toBe(errors[2])
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(onRetry).toHaveBeenCalledTimes(2) // no sleep/callback after the final failure
+    expect(onExhausted).toHaveBeenCalledTimes(1)
+    expect(onExhausted).toHaveBeenCalledWith(errors[2])
+  })
+
+  test('attempts=1 means no retry at all: single call, exhausted immediately', async () => {
+    const err = slowDownError()
+    const fn = jest.fn().mockRejectedValue(err)
+    const sleep = jest.fn(instantSleep)
+    const onExhausted = jest.fn()
+    await expect(retryOnPutLimit(fn, { attempts: 1, sleep, onExhausted })).rejects.toBe(err)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+    expect(onExhausted).toHaveBeenCalledTimes(1)
+  })
+
+  test('sleeps with the computed backoff between attempts', async () => {
+    const sleep = jest.fn(instantSleep)
+    const fn = jest.fn()
+      .mockRejectedValueOnce(slowDownError())
+      .mockResolvedValue({ ETag: 'ok' })
+    await retryOnPutLimit(fn, { attempts: 5, sleep, rng: midRng })
+    expect(sleep).toHaveBeenCalledTimes(1)
+    expect(sleep).toHaveBeenCalledWith(6000)
+  })
+
+  test('env knobs are honoured when opts are not passed', async () => {
+    const prev = { ...process.env }
+    process.env.PUT_RETRY_ATTEMPTS = '2'
+    process.env.PUT_RETRY_BASE_MS = '7000'
+    process.env.PUT_RETRY_MAX_MS = '9000'
+    process.env.PUT_RETRY_MIN_MS = '6000'
+    try {
+      const fn = jest.fn().mockRejectedValue(slowDownError())
+      const sleep = jest.fn(instantSleep)
+      await expect(retryOnPutLimit(fn, { sleep, rng: midRng })).rejects.toBeDefined()
+      expect(fn).toHaveBeenCalledTimes(2)
+      expect(sleep).toHaveBeenCalledWith(7000)
+    } finally {
+      process.env = prev
+    }
+  })
+})


### PR DESCRIPTION
## The defect (2026-08-19 production)

A single browser bulk-backfill sustained a **~12% terminal upload failure rate** (111+ of ~930 files over ~7h) purely because `ingest-service-tasks` treats the s3-writer's explicit backpressure rejection — `503 SlowDown`, `s3-writer in-flight PUT limit reached; retry`, whose message **literally says retry** — as a fatal error: full rollback → status 30 → *"Server failed with processing your file. Please try again later."* Zero of the failed files were ever re-ingested (checked by checksum AND original_filename); bulk users don't click per-file Retry.

The same-day capacity mitigations (s3-writer-ingest replicas 3→4, then KEDA floor 4 / cap 6) reduce collision frequency but the cap is finite — any burst beyond it converts transient backpressure into permanent user-visible failure. This fixes the class.

## The fix

`utils/put-retry.js`: bounded jittered-exponential retry scoped to **exactly** the writer's throttle signal (`err.code === 'SlowDown'`, message-regex fallback for a mangling layer). Defaults: 5 attempts, 6s base → 18s cap, ±30% jitter, **5.5s floor — every delay exceeds the writer's 5s `PUT_ACQUIRE_TIMEOUT`**, so each retry sees a fresh acquire window instead of re-joining the saturated one (the aws-sdk's own fast retries already tried and lost that race). Env-tunable via `PUT_RETRY_{ATTEMPTS,BASE_MS,MAX_MS,MIN_MS}`.

Wired into the segment-PUT loop in `services/rfcx/ingest.js` only. Plus `put_limit_retry` / `put_limit_exhausted` metrics (house histogram-as-counter convention) so the next capacity decision comes from data, not log greps.

## What deliberately does NOT change

- **Only the PUT phase retries.** Every other error propagates on the first attempt — the `segments.js` terminal classification, the 2026-06-30 data-loss-adjacent handled-terminal rules, and consumer ack/nack semantics are byte-identical for non-throttle failures.
- **Exhaustion re-throws the last throttle error raw** → the existing rollback + status 30 + nack→DLQ path handles genuine sustained saturation exactly as before (still operator-redrivable).
- **Idempotent re-PUTs:** segment keys are minted from Core data before the loop and stable across attempts; never re-minted.
- No ack-semantics change — the queue message settles only after the whole ingest outcome is known.

## Verification

- `utils/put-retry.test.js`: 18 unit tests. **Mutation-tested with 9 hand-applied mutants: 8 killed, 1 justified equivalent survivor** (loop-bound widening is masked by the exhaustion `break`; removing that break IS killed). Divergence points enumerated before writing fixtures.
- `services/rfcx/ingest.test.js`: +3 integration tests through the real pipeline (real transcode): transient burst → retried → INGESTED, no rollback (7 PUT calls for 5 segments); sustained saturation → **bounded** 15 attempts → rollback (5 segment deletes + Core source delete) + FAILED + re-throw; non-throttle error → single attempt, fail-fast unchanged.
- eslint clean; full suite: the only failures (`audio.test.js`, `uploads-switch.test.js`) reproduce identically on clean master (local ffmpeg baseline) — not introduced here.

## After this lands

- Soak, then the s3-writer-ingest ScaledObject floor can drop 4→3 (rfcx-local `platform/routing/s3/14-s3-writer-ingest-scaledobject.yaml`).
- Watch `failure_message ILIKE '%processing your file%'` hourly counts (ran 3–43/hr on 08-19) → should go ~0 for this class.
- Related but separate: the rfcx-api Auth0 token-cache bug (the residual 500 trickle) has its own prompt/PR path; the DLQ shovel + 8 residual redrives are gated on that.