### PR TITLE
fix(ingest): report the stored FLAC size, not the intermediate WAV size

### DIFF
--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -136,8 +136,33 @@ async function transcode (filePath, fileData) {
   if (isLosslessFile) { // convert lossless files to flac format
     for (const file of outputFiles) {
       const finalPath = file.path.replace(path.extname(file.path), '.flac')
-      await audioService.convert(file.path, finalPath)
+      const { meta: flacMeta } = await audioService.convert(file.path, finalPath)
       file.path = finalPath
+      // Refresh the segment's byte size from the FLAC we actually store.
+      //
+      // `file.meta` was probed from the pre-conversion WAV segment, so without
+      // this the size reported to Core (and thence to Arbimon's
+      // recordings.file_size) is the UNCOMPRESSED size -- a constant
+      // samples*2 + header for every 60s segment, ~30-40% larger than the FLAC
+      // that is actually uploaded. Observed live 2026-08-21: 97 recordings all
+      // reported 5760258 bytes while the stored objects ranged 3.3-4.3 MB.
+      //
+      // ONLY the size is refreshed. duration/sampleCount are deliberately left
+      // alone: they are corrected upstream by the decode-vs-probe reconciliation
+      // in audioService.split() (the cumulative-opus-timestamp fix), and
+      // re-probing here would discard that correction.
+      // Coerced rather than checked with Number.isFinite() directly: ffprobe
+      // reports format.size as a NUMBER in the build we ship (verified in the
+      // running pod: typeof 'number'), but returns it as a STRING in many other
+      // builds. A strict check would then silently skip the refresh and leave
+      // the WAV size in place -- a fix that quietly does nothing is worse than
+      // no fix, because it looks applied.
+      const flacSize = flacMeta ? Number(flacMeta.size) : NaN
+      if (Number.isFinite(flacSize) && flacSize > 0) {
+        file.meta.size = flacSize
+      } else {
+        console.warn(`[transcode] could not read FLAC size for ${finalPath}; keeping probed size ${file.meta && file.meta.size}`)
+      }
     }
   }
   return {

--- a/services/rfcx/ingest.test.js
+++ b/services/rfcx/ingest.test.js
@@ -316,6 +316,67 @@ describe('Test ingest service', () => {
     expect(storage.deleteObject).not.toHaveBeenCalled()
   })
 
+  // --- segment file_size must describe the STORED FLAC (2026-08-21) ---------
+  // Regression: transcode() converts each split WAV segment to FLAC and updates
+  // file.path, but did NOT refresh file.meta -- so the size reported to Core
+  // (and thence to Arbimon's recordings.file_size) was the UNCOMPRESSED WAV
+  // size, a constant sampleCount*2 + header for every segment of a given
+  // length. Observed live 2026-08-21 on 97 freshly-uploaded recordings, all
+  // reporting 5760258 bytes while the stored objects ranged 3.3-4.3 MB.
+  //
+  // NOTE ON THE MOCKS: the suite-wide beforeEach stubs audioService.convert to
+  // return the SOURCE file's meta (size 6672949) and audioService.split to
+  // return per-segment meta (size 1024+idx). The convert() stub is shared by
+  // BOTH call sites -- the whole-file WAV conversion AND the per-segment FLAC
+  // conversion -- so a naive assertion here reads the stub, not the code. This
+  // test therefore re-stubs convert() per call so the segment conversions
+  // return DISTINCT, segment-specific sizes, which is what the real ffprobe
+  // does (verified: real FLAC segments of this fixture measure 15060/1070288/
+  // 1830924/1867764/1980091 bytes -- all different).
+  test('segment file_size is refreshed from the converted FLAC, not left as the WAV size', async () => {
+    const fileName = 'test-5mins-lv8.flac'
+    const pathFile = path.join(__dirname, '../../test/', fileName)
+    const tempFilePath = tempDirPath + fileName
+    process.env.CACHE_DIRECTORY = tempDirPath
+    fs.copyFile(pathFile, tempFilePath, (err) => { console.info(err) })
+    const upload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+
+    jest.spyOn(storage, 'upload').mockResolvedValue({ ETag: true })
+
+    // Distinct FLAC sizes per segment, mirroring reality. The first call is the
+    // whole-file WAV conversion (source meta); later calls are the per-segment
+    // FLAC conversions.
+    const flacSizes = [15060, 1070288, 1830924, 1867764, 1980091]
+    let convertCall = 0
+    jest.spyOn(audioService, 'convert').mockImplementation(() => {
+      const idx = convertCall++
+      if (idx === 0) {
+        return Promise.resolve({
+          meta: { duration: 299.806032, sampleCount: 13221446, sampleRate: 48000, bitRate: 1, codec: 'pcm_s16le', size: 6672949, checksum: UPLOAD.checksum }
+        })
+      }
+      return Promise.resolve({ meta: { duration: 60, sampleCount: 2880000, size: flacSizes[idx - 1] } })
+    })
+
+    await ingestService.ingest(`${UPLOAD.streamId}/${fileName}`, tempFilePath, UPLOAD.streamId, upload.id)
+
+    expect(segmentService.createStreamFileData).toHaveBeenCalled()
+    // createStreamFileData(stream, payload); payload is camelCase at this point
+    // (it is transformed to snake_case inside the service).
+    const payload = segmentService.createStreamFileData.mock.calls.slice(-1)[0][1]
+    const segments = payload.streamSegments
+    expect(Array.isArray(segments)).toBe(true)
+    expect(segments.length).toBe(flacSizes.length)
+
+    const reported = segments.map(s => Number(s.fileSize))
+    // 1. each segment carries ITS OWN converted size ...
+    expect(reported).toEqual(flacSizes)
+    // 2. ... none is left at the split()-probed WAV size (1024 + idx) ...
+    expect(reported.some((v, i) => v === 1024 + i)).toBe(false)
+    // 3. ... and none is the whole-source size.
+    expect(reported.includes(6672949)).toBe(false)
+  })
+
   test('Exhausted PUT-limit retries roll back and nack exactly like before (bounded attempts)', async () => {
     const fileName = 'test-5mins-lv8.flac'
     const pathFile = path.join(__dirname, '../../test/', fileName)


### PR DESCRIPTION
Segment file_size described the pre-conversion WAV, not the FLAC that is
actually stored. transcode() converts each split segment to FLAC and updates
file.path, but never refreshed file.meta — so the size handed to Core (and from
there to Arbimon's recordings.file_size) was the UNCOMPRESSED size.

MEASURED IN PRODUCTION 2026-08-21: 97 freshly-uploaded recordings all reported
exactly 5760258 bytes (= sampleCount*2 + 258, i.e. 16-bit mono PCM) while the
stored objects ranged 3.3–4.3 MB — the DB overstating real storage by ~40%.
This surfaced immediately after the file_size=0 regression was fixed
(rfcx-api#670): the field went from absent to present-but-wrong.

THE FIX refreshes only the size from the converted FLAC. duration/sampleCount
are deliberately left alone — they are corrected upstream by the decode-vs-probe
reconciliation in audioService.split() (the cumulative-opus-timestamp fix), and
re-probing here would discard that correction.

The value is coerced with Number() before validating. ffprobe reports
format.size as a NUMBER in the build we ship (verified inside the running
ingest-service pod: typeof 'number'), but as a STRING in many other builds; a
strict Number.isFinite() check would then silently skip the refresh and leave
the WAV size in place. A fix that quietly does nothing is worse than no fix,
because it looks applied. A missing/garbage size logs a warning and keeps the
previously probed value rather than corrupting the record.

REGRESSION GUARD — and a warning for whoever edits it next:
the suite-wide beforeEach stubs audioService.convert to return the SOURCE
file's meta (size 6672949) and audioService.split to return per-segment meta
(size 1024+idx). convert() is shared by BOTH call sites — the whole-file WAV
conversion AND the per-segment FLAC conversion — so an assertion written against
the default stubs reads the mock, not the code, and reports the same constant
for every segment. The new test re-stubs convert() per call with distinct
segment sizes mirroring reality (verified against the real fixture: 15060 /
1070288 / 1830924 / 1867764 / 1980091 bytes, all different), then asserts each
segment carries its own converted size, none is left at the split()-probed WAV
size, and none is the whole-source size.

The guard was verified to FAIL against the reverted code and pass with the fix.

12/12 ingest tests pass; eslint clean. The 2 failures in services/audio.test.js
('Can split', 'Can convert') are PRE-EXISTING — reproduced on unmodified master,
local ffmpeg-version sensitivity, unrelated to this change.