### PR TITLE
fix(ingest): unreadable media is a TERMINAL failure, not a retryable one

### DIFF
--- a/routes/uploads.int.test.js
+++ b/routes/uploads.int.test.js
@@ -1004,6 +1004,33 @@ describe('GET /uploads/:id/status', () => {
     })
   })
 
+  // Regression (2026-08-21, OPEN-ITEMS #196): an unreadable/empty source must
+  // surface as review_error. Previously ffprobe failures fell through to the
+  // generic message, which is classified RETRYABLE -- so the API told the
+  // client to re-upload a permanently unreadable file, forever.
+  test('returns review guidance for unreadable media (not retry_upload)', async () => {
+    const dbUpload = await new UploadModel({
+      streamId: '0a1824085e3f',
+      userId: seedValues.primaryUserGuid,
+      status: status.FAILED,
+      failureMessage: 'Audio file could not be read (.wav). The uploaded file is empty, truncated or not valid audio. Re-uploading the same file will not help -- please check the source file on the recorder and upload it again.',
+      timestamp: '2021-06-08T19:26:40.000Z',
+      originalFilename: 'recording.wav'
+    }).save()
+
+    const response = await request(app).get(`/uploads/${dbUpload._id}/status`)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toMatchObject({
+      uploadId: `${dbUpload._id}`,
+      status: status.FAILED,
+      statusName: 'FAILED',
+      terminal: true,
+      retryable: false,
+      nextAction: 'review_error'
+    })
+  })
+
   test('returns forbidden error for upload which is not yours', async () => {
     const dbUpload = await new UploadModel({
       streamId: '0a1824085e3f',

--- a/services/rfcx/ingest.js
+++ b/services/rfcx/ingest.js
@@ -9,6 +9,7 @@ const { chunks } = require('../../utils/array')
 const { getKeyByValue } = require('../../utils/obj')
 const { PROMETHEUS_ENABLED, registerHistogram, pushHistogramMetric } = require('../../services/prometheus')
 const path = require('path')
+const fs = require('fs')
 const moment = require('moment-timezone')
 const TimeTracker = require('../../utils/time-tracker')
 const uploadBucket = process.env.UPLOAD_BUCKET
@@ -37,7 +38,12 @@ const loggerIgnoredErrors = [
   /File extension is not supported/,
   /Stream source file was not created/,
   /Cannot create source file with provided data/,
-  /There is another file with the same timestamp in the stream/
+  /There is another file with the same timestamp in the stream/,
+  // Unreadable/empty/truncated media (2026-08-21): a terminal USER-side data
+  // problem, not a platform fault. The raw ffprobe diagnostic is logged
+  // separately at the throw site, so this only suppresses the duplicate
+  // error-level line in the generic handler.
+  /Audio file could not be read/
 ]
 
 if (PROMETHEUS_ENABLED) {
@@ -272,7 +278,57 @@ async function ingest (fileStoragePath, fileLocalPath, streamId, uploadId) {
     await db.updateUploadStatus(uploadId, db.status.UPLOADED)
     tracker.logAndSetNewPoint(`[${uploadId}] updated upload status in Mongo`)
 
-    const fileData = await audioService.identify(fileLocalPath)
+    // ffprobe failure here means the BYTES ARE NOT DECODABLE AS AUDIO -- a
+    // truncated/empty/garbage upload. That is PERMANENT: re-running the exact
+    // same object through the exact same probe cannot succeed. Classify it as
+    // a terminal IngestionError so it is ACK-dropped and the upload reports
+    // `review_error`, NOT the generic "try again later" message.
+    //
+    // WHY THIS MATTERS (2026-08-21, OPEN-ITEMS #196): the generic message is
+    // the one string routes/uploads.js:isRetryableUpload() treats as RETRYABLE,
+    // so nextActionForUpload() answered `retry_upload` and the client dutifully
+    // re-uploaded FOREVER. One 131072-byte all-zeros file produced 330 upload
+    // rows in 12h (~2.1/min, still climbing) and ~308 DLQ messages/hour. The
+    // client was not misbehaving -- it was obeying the API. Every retry cost an
+    // R2 GET + ffprobe + DB writes, and the DLQ depth it created was
+    // simultaneously (mis)driving KEDA autoscaling.
+    //
+    // Scope deliberately narrow, TWICE OVER:
+    //   1. only the probe-the-source call is wrapped; and
+    //   2. only when the downloaded file is actually PRESENT ON DISK.
+    // A missing/unstatable local file means the DOWNLOAD failed -- that is an
+    // infrastructure fault, not bad user data, and it must keep the old
+    // behaviour (generic retryable message + dead-letter for redrive). Without
+    // this guard a failed download would be blamed on the user's audio and
+    // silently ACK-dropped, losing the redrive path.
+    let localSize = -1
+    try {
+      localSize = fs.statSync(fileLocalPath).size
+    } catch (_) {
+      localSize = -1
+    }
+    let fileData
+    try {
+      fileData = await audioService.identify(fileLocalPath)
+    } catch (probeErr) {
+      if (localSize < 0) {
+        // Download/staging problem -> transient. Re-throw untouched.
+        throw probeErr
+      }
+      // Keep the raw ffprobe diagnostic in the logs for operators; the user
+      // sees the actionable message below, not ffmpeg internals.
+      console.error(
+        `[${uploadId}] Unreadable media: ffprobe failed on ${fileExtension || 'unknown'} ` +
+        `source: ${probeErr && probeErr.message}`
+      )
+      throw new IngestionError(
+        `Audio file could not be read (${fileExtension || 'unknown format'}). ` +
+        'The uploaded file is empty, truncated or not valid audio. ' +
+        'Re-uploading the same file will not help -- please check the source ' +
+        'file on the recorder and upload it again.',
+        db.status.FAILED
+      )
+    }
     tracker.logAndSetNewPoint(`[${uploadId}] identified file with ffmpeg`)
     console.info(`[${uploadId}] Audio metadata`, JSON.stringify(fileData))
     validateAudioMeta(upload, fileData, fileExtension)

--- a/services/rfcx/ingest.test.js
+++ b/services/rfcx/ingest.test.js
@@ -185,6 +185,33 @@ describe('Test ingest service', () => {
     expect(newUpload.failureMessage).toBe('Server failed with processing your file. Please try again later.')
   })
 
+  // Regression (2026-08-21, OPEN-ITEMS #196): an UNREADABLE source (empty /
+  // truncated / not audio) must be TERMINAL, not the generic retryable
+  // failure. Reproduces the production case exactly: a 131072-byte all-zeros
+  // file, whose sha1 the client itself declared, retried ~2.1x/min forever
+  // because routes/uploads.js:isRetryableUpload() treats the generic message
+  // as retryable and the API answered `retry_upload`.
+  test('Unreadable media (empty/zero-byte file) is terminal, NOT retryable', async () => {
+    const fileName = 'test-zero-bytes.wav'
+    const tempFilePath = tempDirPath + fileName
+    process.env.CACHE_DIRECTORY = tempDirPath
+    // 128 KiB of zeros: allocated but never written -- exactly what the
+    // failing production uploads contained (no RIFF header, no audio).
+    fs.writeFileSync(tempFilePath, Buffer.alloc(131072))
+    const upload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+
+    // Terminal IngestionErrors RESOLVE (consumer ACK-drops) rather than
+    // rejecting -- an unreadable file must never be dead-lettered or requeued.
+    await ingestService.ingest(`${UPLOAD.streamId}/${fileName}`, tempFilePath, UPLOAD.streamId, upload.id)
+
+    const newUpload = await UploadModel.findOne({ checksum: UPLOAD.checksum })
+    expect(newUpload.status).toBe(status.FAILED)
+    // The load-bearing assertion: it must NOT be the retryable message.
+    expect(newUpload.failureMessage).not.toBe('Server failed with processing your file. Please try again later.')
+    expect(newUpload.failureMessage).toMatch(/Audio file could not be read/)
+    expect(newUpload.failureMessage).toMatch(/will not help/)
+  })
+
   test('Duplicate error', async () => {
     const fileName = 'test-5mins-lv8.flac'
     const pathFile = path.join(__dirname, '../../test/', fileName)


### PR DESCRIPTION
## Problem

An `ffprobe` failure on the downloaded source means **the bytes are not decodable as audio** (empty / truncated / garbage). That is **permanent** — the same object through the same probe cannot ever succeed.

But it was reported with the generic message:

> `Server failed with processing your file. Please try again later.`

which is the **exact string** `routes/uploads.js:isRetryableUpload()` classifies as retryable. So `nextActionForUpload()` answered **`retry_upload`**, and the client re-uploaded forever.

**The client was not misbehaving — it was obeying the API.**

## Observed in production (2026-08-21)

A single upload on stream `qozs68j9zp5p`:

- source in R2 is **exactly 131,072 bytes of pure zeros** — no RIFF header, no audio
- the client's own declared checksum `67dfd19f…` **is `sha1(128 KiB of zeros)`** ⇒ its local read produced nothing and it never noticed
- **330 upload rows in 12 h**, still arriving at **~2.1/min** at time of writing
- **~308 DLQ messages/hour**, which in turn were (mis)driving KEDA autoscaling on the ingest tier

Each retry cost an R2 GET + ffprobe + DB writes, indefinitely.

## Fix

Throw a terminal `IngestionError` so the message is **ACK-dropped** and the API answers **`review_error`** with actionable text ("Re-uploading the same file will not help — please check the source file on the recorder"). The raw ffprobe diagnostic is still logged for operators.

### Scoped twice over, deliberately

1. **Only the probe call** is wrapped — transient faults (network, storage, Core 5xx) still take the generic retryable path and still dead-letter for redrive.
2. **Only when the local file is present on disk.** A missing local file means the **download** failed — infrastructure, not user data — so it keeps the old behaviour.

⚠️ Point 2 was **caught by the existing `Not found error` test**, which my first attempt broke: without the guard, a failed download would be blamed on the user's audio and **silently ACK-dropped, losing the redrive path**. The guard restores that test to green.

## Tests

- **New unit regression** reproduces the exact production case (128 KiB of zeros) and asserts the message is *not* the retryable one. **Falsification-checked**: it fails against pre-fix code, so it is a real guard rather than a tautology.
- **New API test** asserts `retryable: false` / `nextAction: 'review_error'`.
- Full `services/rfcx/ingest.test.js`: **12/12 pass**. `npm run lint`: clean.
- ⚠️ `services/audio.test.js` and `services/db/uploads-switch.test.js` fail **identically on unmodified master** (verified by stashing) — pre-existing and unrelated to this change.

## Not included

Deduping retries by **resuming an existing upload row** rather than creating a new id per attempt (each retry currently creates a new id, which is *why* sha1 dedup cannot suppress the loop — cluster-wide that's 2,393 rows for 527 distinct files, 4.5×). That is a client-side change and is tracked separately; this PR stops the loop server-side first.

Context: rfcx-local OPEN-ITEMS #196.